### PR TITLE
fix(tooltip/basic): use new react-tooltip dependency compatible with React 16

### DIFF
--- a/components/tooltip/basic/package.json
+++ b/components/tooltip/basic/package.json
@@ -13,6 +13,6 @@
   "license": "ISC",
   "dependencies": {
     "@s-ui/component-dependencies": "1",
-    "react-tooltip": "3.2.7"
+    "react-tooltip": "3.8.4"
   }
 }

--- a/demo/tooltip/basic/playground
+++ b/demo/tooltip/basic/playground
@@ -1,7 +1,7 @@
 const html = '<p>Lorem ipsum dolor sit amet, consectetur <strong>adipisicing</strong> elit, sed do eiusmod tempor incididunt</p>'
 
 return (
-  <div style={{'text-align': 'center'}}>
+  <div style={{'textAlign': 'center'}}>
     <img style={{'margin': '10px'}} data-tip='hello world' data-place='right' src='https://placeholdit.imgix.net/~text?txtsize=20&txt=position%20right&w=210&h=110' />
     <img style={{'margin': '10px'}} data-tip='hello world' data-place='left' src='https://placeholdit.imgix.net/~text?txtsize=20&txt=position%20left&w=210&h=110' />
     <img style={{'margin': '10px'}} data-tip='hello world' data-place='top' src='https://placeholdit.imgix.net/~text?txtsize=20&txt=position%20top&w=210&h=110' />


### PR DESCRIPTION
Just updating react-tooltip dependency in order to make it compatible with React 16 so the component and the demo is working again.