### PR TITLE
Feature/use correct package name for cmp

### DIFF
--- a/components/cmp/banner/package.json
+++ b/components/cmp/banner/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@s-ui/react-cmp-banner",
+  "name": "@schibstedspain/react-cmp-banner",
   "version": "1.5.0",
   "description": "",
   "main": "lib/index.js",
@@ -11,8 +11,8 @@
   "dependencies": {
     "@s-ui/component-dependencies": "1",
     "@s-ui/react-molecule-notification": "1",
-    "@s-ui/react-cmp-services": "1",
-    "@s-ui/react-cmp-modal": "1"
+    "@schibstedspain/react-cmp-services": "1",
+    "@schibstedspain/react-cmp-modal": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/cmp/modal/package.json
+++ b/components/cmp/modal/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@s-ui/react-cmp-modal",
+  "name": "@schibstedspain/react-cmp-modal",
   "version": "1.3.0",
   "description": "",
   "main": "lib/index.js",
@@ -11,8 +11,8 @@
   "dependencies": {
     "@s-ui/component-dependencies": "1",
     "@s-ui/react-atom-switch": "1",
-    "@schibstedspain/sui-atom-button": "1",
-    "@s-ui/react-cmp-services": "1"
+    "@schibstedspain/react-cmp-services": "1",
+    "@schibstedspain/sui-atom-button": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/cmp/services/package.json
+++ b/components/cmp/services/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@s-ui/react-cmp-services",
+  "name": "@schibstedspain/react-cmp-services",
   "version": "1.3.0",
   "description": "",
   "main": "lib/index.js",


### PR DESCRIPTION
In order to being consistent about where the components are, we're changing the cmp components package name to use @schibstedspain instead @s-ui.

PS: Builds are going to fail in the PR as the packages still are not published and they depend on each other.