### PR TITLE
feat(cmp/modal): add a prop to pass to the component an element and open the modal on clicking it

### DIFF
--- a/components/cmp/modal/src/index.js
+++ b/components/cmp/modal/src/index.js
@@ -5,7 +5,37 @@ import {CmpModalContainer} from './CmpModal'
 import CmpServices from '@schibstedspain/react-cmp-services'
 
 class CmpModal extends Component {
+  state = {open: !this.props.elementToOpenOnClick}
+
+  _DOMElementToOpenOnClick = undefined
+
+  _openModal = () => {
+    this.setState({open: true})
+  }
+
+  _handleClickElementEvent = (createEvent = true) => {
+    const event = createEvent ? 'addEventListener' : 'removeEventListener'
+    this._DOMElementToOpenOnClick &&
+      this._DOMElementToOpenOnClick[event]('click', this._openModal)
+  }
+
+  componentDidMount() {
+    const {elementToOpenOnClick} = this.props
+    if (elementToOpenOnClick) {
+      this._DOMElementToOpenOnClick = document.querySelector(
+        elementToOpenOnClick
+      )
+      this._handleClickElementEvent()
+    }
+  }
+
+  componentWillUnmount() {
+    this._handleClickElementEvent(false)
+  }
+
   render() {
+    if (this.state.open === false) return null
+
     return (
       <CmpServices>
         {({getPurposesAndVendors, sendConsents}) => (
@@ -21,7 +51,6 @@ class CmpModal extends Component {
 }
 
 CmpModal.defaultProps = {
-  checkCmpLibraryIsLoaded: true,
   lang: 'es',
   onExit: () => {},
   retrieveConsentsFromCmp: false
@@ -29,11 +58,9 @@ CmpModal.defaultProps = {
 
 CmpModal.propTypes = {
   /**
-   * Flag to determine if we have to check if the cmp library is loaded.
-   * Used as this modal could work standalone or opened by another component, that could have already checked
-   * if the cmp is loaded
+   * CSS Selector to the element to be clicked to open the modal. Used along with openOnClickElement
    */
-  checkCmpLibraryIsLoaded: PropTypes.bool,
+  elementToOpenOnClick: PropTypes.string,
   /**
    * ISO 639-1 code language in order to get the text translated to it
    */
@@ -43,13 +70,13 @@ CmpModal.propTypes = {
    */
   logo: PropTypes.string,
   /**
-   * URL where the user will go in order to know more about the privacy conditions of the website
-   */
-  privacyUrl: PropTypes.string.isRequired,
-  /**
    * Function to be executed when the user wants to exit the modal because he accepted the consents
    */
   onExit: PropTypes.func,
+  /**
+   * URL where the user will go in order to know more about the privacy conditions of the website
+   */
+  privacyUrl: PropTypes.string.isRequired,
   /**
    * Flag to determine if we have to retrieve the consents from the CMP cookie
    * or if it's the first time the user is selecting the consents

--- a/demo/cmp/modal/playground
+++ b/demo/cmp/modal/playground
@@ -52,6 +52,21 @@ class ModalPlayground extends React.Component {
             privacyUrl='#privacy-url-to-configure'
           />
         )}
+        <p>
+          Es posible que quieras mostrar la modal en una página que no esté hecha en React. Para ello, puedes pasarle una prop para indicar el elemento clickable que hará que la modal se abra.
+        </p>
+        <p>
+          <button id='button-to-open-cmp'>
+            Abrir Modal usando prop elementToOpenOnClick
+          </button>
+        </p>
+        <CmpModal
+          onExit={() => {this.setState({ showModal: false })}}
+          retrieveConsentsFromCmp={retrieveConsentsFromCmp}
+          elementToOpenOnClick='#button-to-open-cmp'
+          logo="https://www.schibsted.es/wp-content/themes/Schibsted-spn/img/logo.png"
+          privacyUrl='#privacy-url-to-configure'
+        />
       </React.Fragment>
     )
   }


### PR DESCRIPTION
- Add a new way to open the modal so monolithic applications without access to passing props to the component could use adding an click event to any HTML element to open it so do the usage of the component in a widget seamless.