### PR TITLE
feat(map/basic): add propertyId on markers

### DIFF
--- a/components/map/basic/src/leaflet/marker-manager.js
+++ b/components/map/basic/src/leaflet/marker-manager.js
@@ -31,6 +31,10 @@ class MarkerManager {
 
   createMarker(item, deprecatedLabelNoPrice) {
     const events = [
+      {
+        eventName: 'add',
+        eventHandler: ({target}) => (target._icon.id = target.Id)
+      },
       {eventName: 'click', eventHandler: e => this.isPoiClicked(e)},
       {eventName: 'mouseover', eventHandler: e => this.onMouseOver(e)},
       {eventName: 'mouseout', eventHandler: e => this.onMouseOut(e)},


### PR DESCRIPTION
### Highlight POIS

- [x] Add propertyId on makers using `add` event  be able to find on DOM when we do _mouseover_ on cards.

