### PR TITLE
feat(map/basic): allow customise attribution text displayed at the bottom right of map.

### DIFF
--- a/components/map/basic/src/index.js
+++ b/components/map/basic/src/index.js
@@ -61,6 +61,7 @@ class MapBasic extends Component {
       _deprecatedLabelNoPrice: this.props._deprecatedLabelNoPrice,
       appCode: this.props.appCode,
       appId: this.props.appId,
+      attribution: this.props.attribution,
       dragging: this.props.isInteractable,
       enableViewMenu: this.props.enableViewMenu,
       heatMapUrl: this.props.heatMapUrl,
@@ -172,6 +173,10 @@ MapBasic.propTypes = {
   appCode: PropTypes.string.isRequired,
   appId: PropTypes.string.isRequired,
   /**
+   * The attribution control allows you to display attribution data in a small text box on a map.
+   */
+  attribution: PropTypes.string,
+  /**
    * An array composed by lat and lng like: [lat, lng]
    */
   center: PropTypes.array,
@@ -282,6 +287,8 @@ MapBasic.propTypes = {
 
 MapBasic.defaultProps = {
   _deprecatedLabelNoPrice: '',
+  attribution:
+    'Map &copy; 1987-2017 <a href="http://developer.here.com">HERE</a>',
   center: [40.00237, -3.99902],
   id: 'map-container',
   isInteractable: true,

--- a/components/map/basic/src/leaflet/layer-manager.js
+++ b/components/map/basic/src/leaflet/layer-manager.js
@@ -7,7 +7,15 @@ export default class LayerManager {
     this.layers = {}
   }
 
-  createMapLayers({mapViewModes, maxZoom, minZoom, appId, appCode, id}) {
+  createMapLayers({
+    appCode,
+    appId,
+    attribution,
+    id,
+    mapViewModes,
+    maxZoom,
+    minZoom
+  }) {
     let tileLayers = []
     mapViewModes.forEach((value, index) => {
       const baseMapView = this.getBaseMapView(value)
@@ -18,8 +26,7 @@ export default class LayerManager {
         {
           app_code: appCode,
           app_id: appId,
-          attribution:
-            'Map &copy; 1987-2017 <a href="http://developer.here.com">HERE</a>',
+          attribution: attribution,
           base: baseMapView,
           mapVersion: 'newest',
           maxZoom: maxZoom,

--- a/components/map/basic/src/leaflet/layer-manager.js
+++ b/components/map/basic/src/leaflet/layer-manager.js
@@ -26,7 +26,7 @@ export default class LayerManager {
         {
           app_code: appCode,
           app_id: appId,
-          attribution: attribution,
+          attribution,
           base: baseMapView,
           mapVersion: 'newest',
           maxZoom: maxZoom,


### PR DESCRIPTION
This PR will allow passing by props the text we want to show at the bottom-right side of the leaflet map.
This property is called `attribution`, and you can see its documentation from leaflet in the following link:
https://leafletjs.com/reference-1.3.4.html#control-attribution

