### PR TITLE
fix(cmp/modal): solve footer CMP Modal overflow in some environments

### DIFF
--- a/components/cmp/modal/src/index.scss
+++ b/components/cmp/modal/src/index.scss
@@ -161,6 +161,7 @@ $lh-sui-cmp-modal-title: $lh-xxl !default;
     justify-content: flex-end;
     padding: $p-m $p-l;
     width: 100%;
+    box-sizing: border-box;
   }
 
   &-logo {


### PR DESCRIPTION
As commented in this issue I opened: https://github.com/SUI-Components/schibsted-spain-components/issues/24 in some environments I've seen that the footer overflows.
To solve this we could or omit the `width:100%` or add a `box-sixing: border-box`

ISSUES CLOSED: #24 