### PR TITLE
fix(cmp/modal): fix height of the innerMmodal in IE

### DIFF
--- a/components/cmp/modal/src/index.scss
+++ b/components/cmp/modal/src/index.scss
@@ -151,6 +151,7 @@ $lh-sui-cmp-modal-title: $lh-xxl !default;
     font-size: $fz-sui-cmp-modal-inner;
     overflow-y: scroll;
     padding: $p-l;
+    min-height: 50vh; // fix for IE
   }
 
   &-footer {


### PR DESCRIPTION
In the IE browser the body of the modal has no height. Giving a minimum height we ensure it's shown
correctly.

I decided `50 vh` just because in case the content of the `inner modal` does not height a lot, it will not look weird.

ISSUES CLOSED: #26 