### PR TITLE
fix(layout/mediaQuery): added min breakpoint

### DIFF
--- a/components/layout/mediaQuery/src/breakpoints.js
+++ b/components/layout/mediaQuery/src/breakpoints.js
@@ -1,4 +1,5 @@
 export const BREAKPOINTS = {
+  xxs: 0,
   xs: 480,
   s: 600,
   m: 840,


### PR DESCRIPTION
What does this PR do?
Added min screen breakpoint that is 0. Why? Because there are resolutions like iPhone X that are smaller than XS breakpoint (480). For example, if I have and IphoneX (hopefully.... XD), the screen width is 375 pixels, then XS would be false and this means that we aren't in mobile resolution.

There are two available solutions:
- The first one adds the breakpoint 0 to check XXS breakpoint if is greater that this resolution would be mobile. To me would be more understandable. 

- The second solution could be where we are using this component do: (!XS) also would mean that we are on screen mobile resolution.

I did this PR because I prefer this solution (to me is more understandable) but I would like to know your opinion about it!

Thanks, mates! 👍 