### PR TITLE
feat(map/basic): allow customise the language of map tiles.

### DIFF
--- a/components/map/basic/src/index.js
+++ b/components/map/basic/src/index.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react'
 import PropTypes from 'prop-types'
-import {mapViewModes, NO_OP} from './leaflet/constants'
+import {mapLanguages, mapViewModes, NO_OP} from './leaflet/constants'
 
 class MapBasic extends Component {
   constructor(props) {
@@ -67,6 +67,7 @@ class MapBasic extends Component {
       heatMapUrl: this.props.heatMapUrl,
       icons: this.props.icons,
       id: this.props.id,
+      language: this.props.language,
       latitude: this.props.center[0],
       literals: this.props.literals,
       longitude: this.props.center[1],
@@ -192,6 +193,10 @@ MapBasic.propTypes = {
    * The DOM Id that we would like to have on our map div if none is provided 'map-container' will be its id.
    */
   id: PropTypes.string,
+  /**
+   * Language code for requesting a map tile rendered in a specific language.
+   */
+  language: PropTypes.oneOf(Object.values(mapLanguages)),
   literals: PropTypes.object,
   /**
    * Array of map view modes. Those models are defined could be: mapViewModes.NORMAL, mapViewModes.SATELLITE
@@ -292,6 +297,7 @@ MapBasic.defaultProps = {
   center: [40.00237, -3.99902],
   id: 'map-container',
   isInteractable: true,
+  language: mapLanguages.ENGLISH,
   mapViewModes: [mapViewModes.NORMAL, mapViewModes.SATELLITE],
   maxZoom: 20,
   minZoom: 6,
@@ -316,3 +322,4 @@ MapBasic.defaultProps = {
 MapBasic.displayName = 'MapBasic'
 
 export default MapBasic
+export {mapLanguages}

--- a/components/map/basic/src/leaflet/constants/index.js
+++ b/components/map/basic/src/leaflet/constants/index.js
@@ -6,3 +6,11 @@ export const mapViewModes = {
 export const mapViewNames = ['Mapa', 'Satélite']
 
 export const NO_OP = () => {}
+
+export const mapLanguages = {
+  CATALAN: 'cat',
+  ENGLISH: 'eng',
+  FRENCH: 'fre',
+  GERMAN: 'ger',
+  SPANISH: 'spa'
+}

--- a/components/map/basic/src/leaflet/layer-manager.js
+++ b/components/map/basic/src/leaflet/layer-manager.js
@@ -12,6 +12,7 @@ export default class LayerManager {
     appId,
     attribution,
     id,
+    language,
     mapViewModes,
     maxZoom,
     minZoom
@@ -22,12 +23,13 @@ export default class LayerManager {
       const tileLayer = L.tileLayer(
         'https://{s}.{base}.maps.api.here.com/maptile/2.1/maptile/{mapVersion}/' +
           value +
-          '/{z}/{x}/{y}/256/png8?app_id={app_id}&app_code={app_code}',
+          '/{z}/{x}/{y}/256/png8?app_id={app_id}&app_code={app_code}&lg={language}',
         {
           app_code: appCode,
           app_id: appId,
           attribution,
           base: baseMapView,
+          language,
           mapVersion: 'newest',
           maxZoom: maxZoom,
           minZoom: minZoom,

--- a/demo/map/basic/playground
+++ b/demo/map/basic/playground
@@ -15,6 +15,7 @@ return (
       minZoom={10}
       maxZoom={19}
       scrollWheelZoom={false}
+      language={mapLanguages.SPANISH}
     />
   </div>
 )


### PR DESCRIPTION

According to HERE Maps documentation, **we need to pass an additional query param `lg` in the map tile's URL in order to request them in a foreign language**. By default, all maps are displayed in English.
Docs: https://developer.here.com/api-explorer/rest/map-tile/map-tile-language

If you see in FC Search page map view, it is all always displayed in English, regardless the language you select on the page.
In New Construction's web app, we need to display them in Spanish and French.

So in the end, I have added support to: Spanish, English, Catalan, French, German; keeping the default language as English in order to keep current behaviour.
