### PR TITLE
perf(cmp/banner): load dynamically packages to avoid putting them in the bundle if not needed

### DIFF
--- a/components/cmp/banner/src/CmpBanner/component.js
+++ b/components/cmp/banner/src/CmpBanner/component.js
@@ -5,7 +5,7 @@ import Notification from '@s-ui/react-molecule-notification'
 
 import {CLASS, I18N} from '../settings'
 
-export class CmpBanner extends Component {
+export default class CmpBanner extends Component {
   textRef = React.createRef()
   openCookiesDOM = null
 

--- a/components/cmp/banner/src/CmpBanner/index.js
+++ b/components/cmp/banner/src/CmpBanner/index.js
@@ -1,11 +1,11 @@
-import React, {Component} from 'react'
+import React, {Component, Suspense} from 'react'
 import PropTypes from 'prop-types'
-
-import {CmpBanner} from './component'
-import CmpModal from '@schibstedspain/react-cmp-modal'
 
 const CONSENT_STATUS_NOT_ACCEPTED = 'NOT_ACCEPTED'
 const NO_OP = () => {}
+
+const CmpBanner = React.lazy(() => import('./component'))
+const CmpModal = React.lazy(() => import('@schibstedspain/react-cmp-modal'))
 
 export class CmpBannerContainer extends Component {
   state = {
@@ -75,21 +75,25 @@ export class CmpBannerContainer extends Component {
     return (
       <div ref={this.containerDOMEl}>
         {this.state.showNotification && (
-          <CmpBanner
-            onAccept={this._handleAccept}
-            onConfigure={this._handleReadMore}
-            companyName={companyName}
-            lang={lang}
-          />
+          <Suspense fallback={<div />}>
+            <CmpBanner
+              onAccept={this._handleAccept}
+              onConfigure={this._handleReadMore}
+              companyName={companyName}
+              lang={lang}
+            />
+          </Suspense>
         )}
         {this.state.showModal && (
-          <CmpModal
-            cmpReady
-            lang={lang}
-            logo={logo}
-            onExit={this._handleExitModal}
-            privacyUrl={privacyUrl}
-          />
+          <Suspense fallback={<div />}>
+            <CmpModal
+              cmpReady
+              lang={lang}
+              logo={logo}
+              onExit={this._handleExitModal}
+              privacyUrl={privacyUrl}
+            />
+          </Suspense>
         )}
       </div>
     )


### PR DESCRIPTION
Load dynamically the banner and the modal, only when they are needed so they're not included in the bundle by default.