### PR TITLE
feat(collapsible/basic): fix collapsible-basic styles

### DIFF
--- a/components/collapsible/basic/src/_settings.scss
+++ b/components/collapsible/basic/src/_settings.scss
@@ -16,3 +16,4 @@ $c-collapsible-basic-trigger-icon: $c-primary !default;
 $trs-collapsible-basic-content-normal: max-height .3s ease-in-out !default;
 $trs-collapsible-basic-content-fast: max-height .1s ease-in-out !default;
 $m-h-collapsible-basic-trigger-icon: $m-h !default;
+$ws-collapsible-basic-trigger-label: nowrap !default;

--- a/components/collapsible/basic/src/index.scss
+++ b/components/collapsible/basic/src/index.scss
@@ -37,7 +37,7 @@
       font-weight: $fw-semi-bold;
       overflow: hidden;
       text-overflow: ellipsis;
-      white-space: nowrap;
+      white-space: $ws-collapsible-basic-trigger-label;
     }
   }
 

--- a/components/collapsible/basic/src/index.scss
+++ b/components/collapsible/basic/src/index.scss
@@ -19,10 +19,10 @@
     padding: $p-collapsible-basic-trigger;
 
     &-iconBox {
-      flex: 1;
       transition: $trs-collapsible-basic-trigger-icon;
 
       &-icon {
+        display: block;
         fill: $c-collapsible-basic-trigger-icon !important; // sass-lint:disable-line no-important
         height: $sz-collapsible-basic-trigger-icon;
         margin: auto $m-h-collapsible-basic-trigger-icon;
@@ -32,7 +32,7 @@
 
     &-label {
       color: $c-collapsible-basic;
-      flex: 1 1 100%;
+      flex: 1;
       font-size: $fz-l;
       font-weight: $fw-semi-bold;
       overflow: hidden;


### PR DESCRIPTION
### PR to fix certain errors in the behavior of the component.

1. The label class has been defined as flex:1 so that it occupies 100% of the space left by the iconBox class, which is the one it shares container with.
2. The value of the whitespace style of the label has been defined as a variable, since in the engine we need to change it to the normal value so that the text jumps to a new line.

### Before display: block
![localhost_3001_workbench_collapsible_basic_demo (2)](https://user-images.githubusercontent.com/31726966/54284262-ebd17480-459f-11e9-946d-e54b5850b651.png)

### After display: block
![localhost_3001_workbench_collapsible_basic_demo (1)](https://user-images.githubusercontent.com/31726966/54284161-bfb5f380-459f-11e9-8f8f-3cdf91ccfd2a.png)

