### PR TITLE
Feature/update image slider with new react slidy

### DIFF
--- a/components/image/slider/package.json
+++ b/components/image/slider/package.json
@@ -15,6 +15,6 @@
     "@s-ui/component-dependencies": "1",
     "@schibstedspain/sui-svgiconset": "1",
     "lodash.clonedeep": "4.5.0",
-    "react-slidy": "3"
+    "react-slidy": "4"
   }
 }

--- a/components/image/slider/src/index.js
+++ b/components/image/slider/src/index.js
@@ -29,13 +29,7 @@ class ImageSlider extends Component {
   }
 
   render() {
-    const {
-      dynamicContent,
-      enableCounter,
-      handleClick,
-      images,
-      linkFactory
-    } = this.props
+    const {enableCounter, handleClick, images, linkFactory} = this.props
 
     const slides = this._getSlides(images, linkFactory)
 
@@ -43,12 +37,7 @@ class ImageSlider extends Component {
       slides.length > 0 && (
         <div onClick={handleClick} className="sui-ImageSlider">
           {slides.length > 1 ? (
-            <ReactSlidy
-              {...this._sliderOptions}
-              dynamicContent={dynamicContent}
-            >
-              {slides}
-            </ReactSlidy>
+            <ReactSlidy {...this._sliderOptions}>{slides}</ReactSlidy>
           ) : (
             slides
           )}
@@ -120,7 +109,6 @@ class ImageSlider extends Component {
 }
 
 ImageSlider.propTypes = {
-  dynamicContent: PropTypes.bool,
   /**
    * List of objects with src and alt properties.
    */
@@ -180,13 +168,6 @@ ImageSlider.defaultProps = {
    * If not set, react-slidy will be created with its default properties.
    */
   sliderOptions: {},
-  /**
-   * Whether to enable react-slidy to receive new props and change its content or not.
-   * If you want to set it to true, you also need to set a unique key for every image given over component updates.
-   * It means that if the initial images has keys a and b, when you want to update the component with new content,
-   * new images should have keys c and d... never a or b. Otherwise, images with the same key will not be updated.
-   */
-  dynamicContent: false,
   /**
    * Link component factory.
    */

--- a/demo/image/slider/playground
+++ b/demo/image/slider/playground
@@ -1,92 +1,92 @@
 const props = {
   images: [
     {
-      src: 'http://lorempicsum.com/futurama/400/300/1',
+      src: 'https://picsum.photos/200/300?1',
       alt: 'Some Text',
-      link: 'http://lorempicsum.com/futurama/400/300/1'
+      link: 'https://picsum.photos/200/300?1'
     },
     {
-      src: 'http://lorempicsum.com/futurama/400/300/2',
+      src: 'https://picsum.photos/200/300?2',
       alt: 'Text B'
     },
     {
-      src: 'http://lorempicsum.com/futurama/400/300/3'
+      src: 'https://picsum.photos/200/300?3'
     },
     {
-      src: 'http://lorempicsum.com/futurama/400/300/4',
+      src: 'https://picsum.photos/200/300?4',
       alt: 'Text D'
     },
     {
-      src: 'http://lorempicsum.com/futurama/400/300/5',
+      src: 'https://picsum.photos/200/300?5',
       alt: 'Text E',
       link: 'https://picsum.photos/400/300/?random',
-      key: 'http://lorempicsum.com/futurama/400/300/5'
+      key: 'https://picsum.photos/200/300?5'
     },
     {
-      src: 'http://lorempicsum.com/futurama/400/300/6',
+      src: 'https://picsum.photos/200/300?6',
       alt: 'Text F',
       link: 'https://picsum.photos/400/300/?random',
-      key: 'http://lorempicsum.com/futurama/400/300/6'
+      key: 'https://picsum.photos/200/300?6'
     },
     {
-      src: 'http://lorempicsum.com/futurama/400/300/7',
+      src: 'https://picsum.photos/200/300?7',
       alt: 'Text G'
     },
     {
-      src: 'http://lorempicsum.com/futurama/400/300/8',
+      src: 'https://picsum.photos/200/300?8',
       alt: 'Text G'
     },
     {
-      src: 'http://lorempicsum.com/futurama/400/300/9',
+      src: 'https://picsum.photos/200/300?9',
       alt: 'Text G'
     },
     {
-      src: 'http://lorempicsum.com/futurama/400/300/1',
+      src: 'https://picsum.photos/200/300?1',
       alt: 'Some Text',
-      link: 'http://lorempicsum.com/futurama/400/300/1'
+      link: 'https://picsum.photos/200/300?1'
     },
     {
-      src: 'http://lorempicsum.com/futurama/400/300/2',
+      src: 'https://picsum.photos/200/300?2',
       alt: 'Text B'
     },
     {
-      src: 'http://lorempicsum.com/futurama/400/300/3'
+      src: 'https://picsum.photos/200/300?3'
     },
     {
-      src: 'http://lorempicsum.com/futurama/400/300/4',
+      src: 'https://picsum.photos/200/300?4',
       alt: 'Text D'
     },
     {
-      src: 'http://lorempicsum.com/futurama/400/300/5',
+      src: 'https://picsum.photos/200/300?5',
       alt: 'Text E',
       link: 'https://picsum.photos/400/300/?random',
-      key: 'http://lorempicsum.com/futurama/400/300/5'
+      key: 'https://picsum.photos/200/300?5'
     },
     {
-      src: 'http://lorempicsum.com/futurama/400/300/6',
+      src: 'https://picsum.photos/200/300?6',
       alt: 'Text F',
       link: 'https://picsum.photos/400/300/?random',
-      key: 'http://lorempicsum.com/futurama/400/300/6'
+      key: 'https://picsum.photos/200/300?6'
     },
     {
-      src: 'http://lorempicsum.com/futurama/400/300/7',
+      src: 'https://picsum.photos/200/300?7',
       alt: 'Text G'
     },
     {
-      src: 'http://lorempicsum.com/futurama/400/300/8',
+      src: 'https://picsum.photos/200/300?8',
       alt: 'Text G'
     },
     {
-      src: 'http://lorempicsum.com/futurama/400/300/9',
+      src: 'https://picsum.photos/200/300?9',
       alt: 'Text G'
     },
     {
-      src: 'http://lorempicsum.com/futurama/400/300/1',
+      src: 'https://picsum.photos/200/300?1',
       alt: 'Some Text',
-      link: 'http://lorempicsum.com/futurama/400/300/1'
+      link: 'https://picsum.photos/200/300?1'
     },
     {
-      src: 'http://lorempicsum.com/futurama/400/300/2',
+      src: 'https://picsum.photos/200/300?2',
       alt: 'Text B'
     }
   ],

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "ISC",
   "devDependencies": {
     "@s-ui/precommit": "2",
-    "@s-ui/studio": "5",
+    "@s-ui/studio": "6",
     "babel-jest": "20.0.3",
     "enzyme": "3.3.0",
     "enzyme-adapter-react-16": "1.1.1",


### PR DESCRIPTION
- Update to react-slidy@4 with some performance improvements and fixes with mobile scrolling.
- Remove not needed anymore DynamicContent as react-slidy now handles it automatically.
- Publish as a major as it's removing a prop and react-slidy now doesn't put classes (some styling could break and need to be adapted).
- Fix the demo