### PR TITLE
Feature/define color vars

### DIFF
--- a/components/dropdown/basic/src/index.scss
+++ b/components/dropdown/basic/src/index.scss
@@ -38,7 +38,7 @@
     justify-content: space-between;
 
     &:hover {
-      color: $c-accent;
+      color: $c-dropdown-basic-button-hover;
     }
 
     &Wrap {
@@ -75,7 +75,7 @@
       width: $size-dropdown-icon;
 
       [class$='-button']:hover &:first-child {
-        fill: $c-accent !important;
+        fill: $c-dropdown-basic-button-icon !important;
       }
 
       &:not(:last-child) {
@@ -157,7 +157,7 @@
         padding-right: $p-xl;
 
         &:hover {
-          color: $c-accent;
+          color: $c-dropdown-basic-list-link;
         }
       }
     }

--- a/components/dropdown/user/src/index.scss
+++ b/components/dropdown/user/src/index.scss
@@ -125,7 +125,7 @@
 
         &:hover,
         &Highlight {
-          color: $c-accent;
+          color: $c-dropdown-user-link-highlight;
         }
       }
 
@@ -136,11 +136,11 @@
         width: $size-dropdown-icon;
 
         &Highlight {
-          fill: $c-accent !important;
+          fill: $c-dropdown-user-icon-highlight !important;
         }
 
         :hover > & {
-          fill: $c-accent !important;
+          fill: $c-dropdown-user-icon-hover !important;
         }
       }
 

--- a/components/topbar/user/src/index.js
+++ b/components/topbar/user/src/index.js
@@ -245,7 +245,7 @@ class TopbarUser extends Component {
             title={navCtaText}
             leftIcon={<navCTA.icon svgClass="sui-TopbarUser-ctaButtonIcon" />}
             size="small"
-            type="accent"
+            type="primary"
             onClick={onCTAClick}
           >
             {navCtaText}

--- a/components/topbar/user/src/index.scss
+++ b/components/topbar/user/src/index.scss
@@ -45,9 +45,6 @@ $maw-topbar-user-nav: 350px !default;
   }
 
   &-toggle {
-    &.has-notifications {
-      @include sui-badge-notification(true, 2px, 12px);
-    }
     @include reset-button;
     @include media-breakpoint-up(m) {
       display: none;
@@ -55,8 +52,12 @@ $maw-topbar-user-nav: 350px !default;
     margin-left: -$m-h;
     padding: $p-v $p-h;
 
+    &.has-notifications {
+      @include sui-badge-notification(true, 2px, 12px);
+    }
+
     &Icon {
-      fill: $c-primary !important;
+      fill: $c-accent !important;
       height: $size-topbar-user-toggle-icon;
       width: $size-topbar-user-toggle-icon;
     }


### PR DESCRIPTION
- swapping `topbar user` primary/accent color vars (only used in coches)
- define `dropdown user` color vars so we can overwrite them in our themes
- define `dropdown basic` color vars so we can overwrite them in our themes

related PR https://github.com/SUI-Components/sui-theme/pull/171
https://github.schibsted.io/scmspain/frontend-mt--uilib-theme/pull/111