### PR TITLE
adding a required optional attribute for select

### DIFF
--- a/components/form/select/src/index.js
+++ b/components/form/select/src/index.js
@@ -8,6 +8,7 @@ export default function FormSelect({
   onChange,
   options,
   prominent,
+  required,
   title,
   value
 }) {
@@ -24,6 +25,7 @@ export default function FormSelect({
       onChange={wrappedOnChange}
       title={title}
       value={value}
+      required={required}
     >
       {options.map(({content, key, value}, index) => {
         const optionKey = key || index
@@ -72,6 +74,10 @@ FormSelect.propTypes = {
    * Title attribute of the select
    */
   title: PropTypes.string,
+  /**
+   * required attribute for combobox
+   */
+  required: PropTypes.bool,
   /**
    * Actual value for the select
    */


### PR DESCRIPTION
This pull request changes the behaviour of dropdown box in fotocasa/detail/Report 
It forces user to select a reason for reporting a property, before this change 'Selecciona' was an option to submit. After this change it will be an invalid option to submit. 

Apart from this change, frontend-fc--uilib-components needs to be changed too
<img width="470" alt="Screenshot 2019-05-06 at 14 39 54" src="https://user-images.githubusercontent.com/3046661/57225770-9a78bb00-700d-11e9-8725-1204ce847868.png">
