### PR TITLE
feat(section/info): Remove unnecessary padding

### DIFF
--- a/components/section/info/src/index.js
+++ b/components/section/info/src/index.js
@@ -1,16 +1,22 @@
 import React, {Component} from 'react'
 import PropTypes from 'prop-types'
+import cx from 'classnames'
 
 const baseClass = 'sui-SectionInfo'
+const titleClass = `${baseClass}-title`
 
 class SectionInfo extends Component {
   render() {
     const {title, children} = this.props
 
+    const contentClass = cx(`${baseClass}-content`, {
+      [`${baseClass}-content--withoutTitle`]: !title
+    })
+
     return (
       <section className={baseClass}>
-        {title && <h3 className={`${baseClass}-title`}>{title}</h3>}
-        <div className={`${baseClass}-content`}>{children}</div>
+        {title && <h3 className={titleClass}>{title}</h3>}
+        <div className={contentClass}>{children}</div>
       </section>
     )
   }

--- a/components/section/info/src/index.scss
+++ b/components/section/info/src/index.scss
@@ -40,5 +40,9 @@
     font-size: $fz-section-info-content;
     margin: $m-section-info-content;
     padding: $p-section-info-content;
+
+    &--withoutTitle {
+      padding: 0;
+    }
   }
 }


### PR DESCRIPTION
## Description

When SectionInfo has no title it has unnecessary padding.

## Demostration

### Before
![image](https://user-images.githubusercontent.com/13108014/58010942-9c547b00-7af1-11e9-8e28-d8acdaf9bc9b.png)

### After
![image](https://user-images.githubusercontent.com/13108014/58010959-a2e2f280-7af1-11e9-8096-203a56ff504a.png)

