### PR TITLE
feat(error/appBoundary): add silent prop

### DIFF
--- a/components/error/appBoundary/src/index.js
+++ b/components/error/appBoundary/src/index.js
@@ -1,19 +1,29 @@
 import React, {Component, Fragment, Suspense} from 'react'
 import PropTypes from 'prop-types'
+import MoleculeNotification from '@s-ui/react-molecule-notification'
 
 const CLOSE_ANIMATION_TIME = 1000
-const MoleculeNotification = React.lazy(() =>
-  import(/* webpackChunkName: "MoleculeNotification" */ '@s-ui/react-molecule-notification')
-)
 
 class ErrorAppBoundary extends Component {
   state = {errorCount: 0, hasError: false}
 
   componentDidCatch(errorMessage, errorStack) {
-    const {errorThreshold, onError, redirectUrlOnBreakingThreshold} = this.props
+    const {
+      errorThreshold,
+      onError,
+      redirectUrlOnBreakingThreshold,
+      silent
+    } = this.props
     const {errorCount} = this.state
 
     onError({errorMessage, errorStack})
+
+    // if silent prop is activated, then only log on the console and don't show notification
+    if (silent) {
+      console.error(silent)
+      return
+    }
+
     this.setState({errorCount: errorCount + 1})
 
     return errorCount >= errorThreshold
@@ -31,31 +41,32 @@ class ErrorAppBoundary extends Component {
   }
 
   render() {
-    const {buttonLabel, children, message} = this.props
+    const {buttonLabel, children, message, silent} = this.props
 
     return (
       <Fragment>
         {children}
-        {this.state.hasError && (
-          <div className="sui-ErrorAppBoundary-notification">
-            <Suspense fallback={<div />}>
-              <MoleculeNotification
-                buttons={[
-                  {
-                    type: 'secondary',
-                    negative: true,
-                    children: buttonLabel,
-                    onClick: this._onCloseNotification
-                  }
-                ]}
-                onClose={this._onCloseNotification}
-                type="warning"
-                text={message}
-                position="bottom"
-              />
-            </Suspense>
-          </div>
-        )}
+        {this.state.hasError &&
+          !silent(
+            <div className="sui-ErrorAppBoundary-notification">
+              <Suspense fallback={<div />}>
+                <MoleculeNotification
+                  buttons={[
+                    {
+                      type: 'secondary',
+                      negative: true,
+                      children: buttonLabel,
+                      onClick: this._onCloseNotification
+                    }
+                  ]}
+                  onClose={this._onCloseNotification}
+                  type="warning"
+                  text={message}
+                  position="bottom"
+                />
+              </Suspense>
+            </div>
+          )}
       </Fragment>
     )
   }
@@ -92,13 +103,18 @@ ErrorAppBoundary.propTypes = {
    * If the numberOfToleratedErrores is surpassed, then we could redirect the user to a different
    * URL in order to inform him that the web is definitely broken and unusable
    */
-  redirectUrlOnBreakingThreshold: PropTypes.string
+  redirectUrlOnBreakingThreshold: PropTypes.string,
+  /**
+   * Defines if the error must be shown with a Molecule Notification. If `silent` is true, the error will be logged only on the console
+   */
+  silent: PropTypes.bool
 }
 
 ErrorAppBoundary.defaultProps = {
   buttonLabel: 'OK',
   message: 'Error',
   errorThreshold: 4,
+  silent: false,
   onError: ({errorMessage, errorStack}) =>
     console.error({errorMessage, errorStack}) // eslint-disable-line
 }

--- a/components/error/appBoundary/src/index.js
+++ b/components/error/appBoundary/src/index.js
@@ -47,7 +47,7 @@ class ErrorAppBoundary extends Component {
       <Fragment>
         {children}
         {this.state.hasError &&
-          !silent(
+          !silent && (
             <div className="sui-ErrorAppBoundary-notification">
               <Suspense fallback={<div />}>
                 <MoleculeNotification


### PR DESCRIPTION
Add a way to silent the error in case the developer knows is an error not important. For example, when the error is caused for a well-known no compatibility with a specific browser version.