### PR TITLE
feat(form/builder): refactor submit action

### DIFF
--- a/components/form/builder/README.md
+++ b/components/form/builder/README.md
@@ -188,7 +188,7 @@ when one of the fields of the form changes state, this function sends to the wra
   <form className={FORM_WRAP_CLASS} onSubmit={handleSubmit}>
     <FormBuilder
       config={ptaFormSettings}
-      isSubmited={isSubmited}
+      isSubmitted={isSubmitted}
       onLoad={handleLoad}
       onSelect={handleSelect}
       onInputChange={handleInputChange}

--- a/components/form/builder/README.md
+++ b/components/form/builder/README.md
@@ -179,18 +179,26 @@ Once the user selects an item, `onChange` func will be triggered. This func will
 
 so the form `formBuilder` will update the state adding the options list to the `city` field.
 
-### onSubmit
+### onError
+when one of the fields of the form changes state, this function sends to the wrapper component, the error state of these fields
 
 ```javascript
-  const onSubmit = ({params}) => {
-    console.log(params) // {country: 0, city: 1}
-  }
+  const handleError = error => consol.elog(error) // {country: 'required', city: 'required'}
+
+  <form className={FORM_WRAP_CLASS} onSubmit={handleSubmit}>
+    <FormBuilder
+      config={ptaFormSettings}
+      isSubmited={isSubmited}
+      onLoad={handleLoad}
+      onSelect={handleSelect}
+      onInputChange={handleInputChange}
+      onError={handleError}
+    />
+    <AtomButtom isSubmit disabled={hasErrors}>
+      {submitText}
+    </AtomButtom>
+  </form>
 ```
-
-
-### submitText
-Sets the submit button text
-
 
 ### Auto-cleaning the form
 

--- a/components/form/builder/package.json
+++ b/components/form/builder/package.json
@@ -15,7 +15,6 @@
     "@s-ui/react-molecule-input-field": "2",
     "@s-ui/react-molecule-select-field": "1",
     "@s-ui/react-molecule-textarea-field": "2",
-    "@schibstedspain/sui-atom-button": "1",
     "@schibstedspain/mt-svg-icons": "1"
   },
   "keywords": [],

--- a/components/form/builder/src/components/button-group.js
+++ b/components/form/builder/src/components/button-group.js
@@ -7,7 +7,17 @@ import MoleculeField from '@s-ui/react-molecule-field'
 
 import WithValidator from '../validatorHoC/WithValidator'
 
-const ButtonGroup = ({errorText, label, id, value, items, onChange}) => {
+const ButtonGroup = ({
+  errorText,
+  field,
+  label,
+  id,
+  value,
+  items,
+  onChange,
+  onError
+}) => {
+  errorText && onError({[field]: errorText})
   return (
     <MoleculeField label={label} name={id} errorText={errorText}>
       <MoleculeButtonGroup type="secondary" fullWidth>
@@ -34,11 +44,13 @@ ButtonGroup.displayName = 'ButtonGroup'
 
 ButtonGroup.propTypes = {
   errorText: PropTypes.string,
+  field: PropTypes.string,
   value: PropTypes.object,
   label: PropTypes.string,
   id: PropTypes.string,
   items: PropTypes.arrayOf(PropTypes.obj),
-  onChange: PropTypes.func
+  onChange: PropTypes.func,
+  onError: PropTypes.func
 }
 
 export default WithValidator(ButtonGroup)

--- a/components/form/builder/src/components/button-group.js
+++ b/components/form/builder/src/components/button-group.js
@@ -17,7 +17,7 @@ const ButtonGroup = ({
   onChange,
   onError
 }) => {
-  errorText && onError({[field]: errorText})
+  onError({[field]: errorText})
   return (
     <MoleculeField label={label} name={id} errorText={errorText}>
       <MoleculeButtonGroup type="secondary" fullWidth>

--- a/components/form/builder/src/components/input.js
+++ b/components/form/builder/src/components/input.js
@@ -16,7 +16,7 @@ const Input = ({
   onError,
   ...props
 }) => {
-  errorText && onError({[field]: errorText})
+  onError({[field]: errorText})
   return (
     <MoleculeInputField
       {...props}

--- a/components/form/builder/src/components/input.js
+++ b/components/form/builder/src/components/input.js
@@ -6,14 +6,17 @@ import WithValidator from '../validatorHoC/WithValidator'
 
 const Input = ({
   type,
+  field,
   errorText,
   label,
   id,
   value,
   placeholder,
   onChange,
+  onError,
   ...props
 }) => {
+  errorText && onError({[field]: errorText})
   return (
     <MoleculeInputField
       {...props}
@@ -32,12 +35,14 @@ Input.displayName = 'Input'
 
 Input.propTypes = {
   type: PropTypes.string,
+  field: PropTypes.string,
   errorText: PropTypes.string,
   label: PropTypes.string,
   id: PropTypes.string,
   value: PropTypes.string,
   placeholder: PropTypes.string,
-  onChange: PropTypes.func
+  onChange: PropTypes.func,
+  onError: PropTypes.func
 }
 
 export default WithValidator(Input)

--- a/components/form/builder/src/components/select.js
+++ b/components/form/builder/src/components/select.js
@@ -11,6 +11,7 @@ import WithValidator from '../validatorHoC/WithValidator'
 
 const Select = ({
   errorText,
+  field,
   label,
   id,
   value,
@@ -18,10 +19,12 @@ const Select = ({
   placeholder,
   disabled,
   onChange,
+  onError,
   BASE_CLASS
 }) => {
   const FORM_ICON_CLOSE_CLASS = `${BASE_CLASS}-iconSelectClose`
   const FORM_ICON_ARROW_CLASS = `${BASE_CLASS}-iconSelectArrow`
+  errorText && onError({[field]: errorText})
   return (
     <MoleculeSelectField
       iconCloseTag={<IconClose size={10} svgClass={FORM_ICON_CLOSE_CLASS} />}
@@ -50,6 +53,7 @@ Select.displayName = 'Select'
 
 Select.propTypes = {
   errorText: PropTypes.string,
+  field: PropTypes.string,
   label: PropTypes.string,
   id: PropTypes.string,
   value: PropTypes.string,
@@ -57,6 +61,7 @@ Select.propTypes = {
   placeholder: PropTypes.string,
   disabled: PropTypes.bool,
   onChange: PropTypes.func,
+  onError: PropTypes.func,
   BASE_CLASS: PropTypes.string
 }
 

--- a/components/form/builder/src/components/select.js
+++ b/components/form/builder/src/components/select.js
@@ -24,7 +24,7 @@ const Select = ({
 }) => {
   const FORM_ICON_CLOSE_CLASS = `${BASE_CLASS}-iconSelectClose`
   const FORM_ICON_ARROW_CLASS = `${BASE_CLASS}-iconSelectArrow`
-  errorText && onError({[field]: errorText})
+  onError({[field]: errorText})
   return (
     <MoleculeSelectField
       iconCloseTag={<IconClose size={10} svgClass={FORM_ICON_CLOSE_CLASS} />}

--- a/components/form/builder/src/components/text-area.js
+++ b/components/form/builder/src/components/text-area.js
@@ -16,7 +16,7 @@ const TextArea = ({
   onChange,
   onError
 }) => {
-  errorText && onError({[field]: errorText})
+  onError({[field]: errorText})
   return (
     <MoleculeTextareaField
       errorText={errorText}

--- a/components/form/builder/src/components/text-area.js
+++ b/components/form/builder/src/components/text-area.js
@@ -7,13 +7,16 @@ import WithValidator from '../validatorHoC/WithValidator'
 
 const TextArea = ({
   errorText,
+  field,
   label,
   id,
   value,
   placeholder,
   size,
-  onChange
+  onChange,
+  onError
 }) => {
+  errorText && onError({[field]: errorText})
   return (
     <MoleculeTextareaField
       errorText={errorText}
@@ -31,12 +34,14 @@ TextArea.displayName = 'TextArea'
 
 TextArea.propTypes = {
   errorText: PropTypes.string,
+  field: PropTypes.string,
   size: PropTypes.string,
   label: PropTypes.string,
   id: PropTypes.string,
   value: PropTypes.string,
   placeholder: PropTypes.string,
-  onChange: PropTypes.func
+  onChange: PropTypes.func,
+  onError: PropTypes.func
 }
 
 export default WithValidator(TextArea)

--- a/components/form/builder/src/index.js
+++ b/components/form/builder/src/index.js
@@ -384,6 +384,7 @@ FormBuilder.propTypes = {
   onInputChange: PropTypes.func.isRequired,
   /** Get the submit state of the form */
   isSubmited: PropTypes.bool,
+  /** Send field error state to wrapper */
   onError: PropTypes.func
 }
 

--- a/components/form/builder/src/index.js
+++ b/components/form/builder/src/index.js
@@ -22,7 +22,7 @@ class FormBuilder extends Component {
     this._config = config
     this._formFields = Object.keys(this._config)
     this.state = {
-      isSubmited: false,
+      isSubmitted: false,
       hasErrors: false
     }
   }
@@ -176,7 +176,7 @@ class FormBuilder extends Component {
    */
   _renderSelect = ({
     errors,
-    isSubmited,
+    isSubmitted,
     field,
     label,
     id,
@@ -188,7 +188,7 @@ class FormBuilder extends Component {
     return (
       <Select
         errors={errors}
-        isSubmited={isSubmited}
+        isSubmitted={isSubmitted}
         disabled={disabled}
         key={field}
         field={field}
@@ -207,14 +207,14 @@ class FormBuilder extends Component {
    * Function responsible for rendering the ButtonGroup component, generating the data according to the received field name
    * @param {Object} props
    */
-  _renderButtonGroup = ({errors, isSubmited, field, label, id, disabled}) => {
+  _renderButtonGroup = ({errors, isSubmitted, field, label, id, disabled}) => {
     const items = this.state[field]
     const value = this._getSelectedFieldName(items)
     return (
       items && (
         <ButtonGroup
           errors={errors}
-          isSubmited={isSubmited}
+          isSubmitted={isSubmitted}
           disabled={disabled}
           key={field}
           field={field}
@@ -235,7 +235,7 @@ class FormBuilder extends Component {
    */
   _renderInput = ({
     errors,
-    isSubmited,
+    isSubmitted,
     field,
     label,
     id,
@@ -246,7 +246,7 @@ class FormBuilder extends Component {
     return (
       <Input
         errors={errors}
-        isSubmited={isSubmited}
+        isSubmitted={isSubmitted}
         key={field}
         field={field}
         label={label}
@@ -266,7 +266,7 @@ class FormBuilder extends Component {
    */
   _renderTextArea = ({
     errors,
-    isSubmited,
+    isSubmitted,
     field,
     label,
     id,
@@ -277,7 +277,7 @@ class FormBuilder extends Component {
     return (
       <TextArea
         errors={errors}
-        isSubmited={isSubmited}
+        isSubmitted={isSubmitted}
         key={field}
         field={field}
         label={label}
@@ -317,13 +317,13 @@ class FormBuilder extends Component {
   _renderFormField = (field, index) => {
     const capitalizedKey = toCapitalCase(field)
     const disabled = !this.state[field]
-    const {isSubmited} = this.props
+    const {isSubmitted} = this.props
     const id = `${BASE_CLASS}-${field}`
     const props = {
       field,
       id,
       disabled,
-      isSubmited,
+      isSubmitted,
       BASE_CLASS,
       ...this._config[field]
     }
@@ -383,7 +383,7 @@ FormBuilder.propTypes = {
   /** Function executed on input field change. */
   onInputChange: PropTypes.func.isRequired,
   /** Get the submit state of the form */
-  isSubmited: PropTypes.bool,
+  isSubmitted: PropTypes.bool,
   /** Send field error state to wrapper */
   onError: PropTypes.func
 }

--- a/components/form/builder/src/index.js
+++ b/components/form/builder/src/index.js
@@ -6,7 +6,6 @@ import Select from './components/select'
 import ButtonGroup from './components/button-group'
 import Input from './components/input'
 import TextArea from './components/text-area'
-import AtomButtom from '@schibstedspain/sui-atom-button'
 
 import {toCapitalCase} from '@s-ui/js/lib/string'
 
@@ -14,18 +13,17 @@ const INITIAL_LIST_ITEM_STATE = undefined
 const INITIAL_INPUT_ITEM_STATE = ''
 
 const BASE_CLASS = 'sui-FormBuilder'
-const FORM_WRAP_CLASS = `${BASE_CLASS}-wrap`
 const FORM_ITEM_CLASS = `${BASE_CLASS}-item`
 const FORM_ITEM_DISABLED_CLASS = `is-disabled`
 
 class FormBuilder extends Component {
-  constructor({config, submitText}) {
+  constructor({config}) {
     super()
     this._config = config
     this._formFields = Object.keys(this._config)
-    this._submitText = submitText
     this.state = {
-      showErrors: false
+      isSubmited: false,
+      hasErrors: false
     }
   }
 
@@ -61,7 +59,7 @@ class FormBuilder extends Component {
     }, {})
 
   /**
-   * Executes the *props.onChange* function that is passed via props, to request a list based on the fieldname and current parameters
+   * Executes the *props.onSelect* function that is passed via props, to request a list based on the fieldname and current parameters
    * @param {string} nextField
    * @param {Object} currentField
    * @param {string} currentValueId
@@ -72,12 +70,12 @@ class FormBuilder extends Component {
       currentField,
       currentValueId
     )
-    const items = await this.props.onChange({nextField, params})
+    const items = await this.props.onSelect({nextField, params})
     return items
   }
 
   /**
-   * From a field name, returns the previous values to that field of the form, to make the request to *props.onChange* through the generated parameters
+   * From a field name, returns the previous values to that field of the form, to make the request to *props.onSelect* through the generated parameters
    * @param {string} nextField
    * @param {Object} currentField
    * @param {string} currentValueId
@@ -124,7 +122,7 @@ class FormBuilder extends Component {
   _getSelectedFieldId = field => {
     const isArray = Array.isArray(field)
     const selectedItem = isArray && field.find(({selected}) => selected)
-    return selectedItem && selectedItem.id
+    return selectedItem ? selectedItem.id : field
   }
 
   /**
@@ -141,7 +139,7 @@ class FormBuilder extends Component {
     })
 
   /**
-   * Function that manages the onChange method, setting the Value and List states, and clear the data from the fields subsequent to the current selection
+   * Function that manages the onSelect method, setting the Value and List states, and clear the data from the fields subsequent to the current selection
    * Prevents the setState method from running when the user selects the same item that was previously selected
    * @param {string} field
    * @param {string} value
@@ -162,12 +160,13 @@ class FormBuilder extends Component {
   }
 
   /**
-   * Function that manages the onChange method form input and text-areas, setting the value
+   * Function that manages the onInputChange method form input and text-areas, setting the value
    * @param {string} field
    * @param {string} value
    */
   _handleInputChange = (field, value) => {
     const inputValue = {[field]: value}
+    this.props.onInputChange(inputValue)
     this.setState({...inputValue})
   }
 
@@ -177,7 +176,7 @@ class FormBuilder extends Component {
    */
   _renderSelect = ({
     errors,
-    showErrors,
+    isSubmited,
     field,
     label,
     id,
@@ -189,15 +188,17 @@ class FormBuilder extends Component {
     return (
       <Select
         errors={errors}
-        showErrors={showErrors}
+        isSubmited={isSubmited}
         disabled={disabled}
         key={field}
+        field={field}
         label={label}
         id={id}
         value={value}
         items={items}
         placeholder={placeholder}
         onChange={name => this._handleChange(field, name)}
+        onError={error => this.props.onError(error)}
       />
     )
   }
@@ -206,21 +207,23 @@ class FormBuilder extends Component {
    * Function responsible for rendering the ButtonGroup component, generating the data according to the received field name
    * @param {Object} props
    */
-  _renderButtonGroup = ({errors, showErrors, field, label, id, disabled}) => {
+  _renderButtonGroup = ({errors, isSubmited, field, label, id, disabled}) => {
     const items = this.state[field]
     const value = this._getSelectedFieldName(items)
     return (
       items && (
         <ButtonGroup
           errors={errors}
-          showErrors={showErrors}
+          isSubmited={isSubmited}
           disabled={disabled}
           key={field}
+          field={field}
           label={label}
           id={id}
           value={value}
           items={items}
           onChange={name => this._handleChange(field, name)}
+          onError={error => this.props.onError(error)}
         />
       )
     )
@@ -232,7 +235,7 @@ class FormBuilder extends Component {
    */
   _renderInput = ({
     errors,
-    showErrors,
+    isSubmited,
     field,
     label,
     id,
@@ -243,14 +246,16 @@ class FormBuilder extends Component {
     return (
       <Input
         errors={errors}
-        showErrors={showErrors}
+        isSubmited={isSubmited}
         key={field}
+        field={field}
         label={label}
         id={id}
         value={value}
         type={inputType}
         placeholder={placeholder}
         onChange={value => this._handleInputChange(field, value)}
+        onError={error => this.props.onError(error)}
       />
     )
   }
@@ -261,7 +266,7 @@ class FormBuilder extends Component {
    */
   _renderTextArea = ({
     errors,
-    showErrors,
+    isSubmited,
     field,
     label,
     id,
@@ -272,14 +277,16 @@ class FormBuilder extends Component {
     return (
       <TextArea
         errors={errors}
-        showErrors={showErrors}
+        isSubmited={isSubmited}
         key={field}
+        field={field}
         label={label}
         id={id}
         value={value}
         size={size}
         placeholder={placeholder}
         onChange={value => this._handleInputChange(field, value)}
+        onError={error => this.props.onError(error)}
       />
     )
   }
@@ -310,13 +317,13 @@ class FormBuilder extends Component {
   _renderFormField = (field, index) => {
     const capitalizedKey = toCapitalCase(field)
     const disabled = !this.state[field]
-    const {showErrors} = this.state
+    const {isSubmited} = this.props
     const id = `${BASE_CLASS}-${field}`
     const props = {
       field,
       id,
       disabled,
-      showErrors,
+      isSubmited,
       BASE_CLASS,
       ...this._config[field]
     }
@@ -334,27 +341,14 @@ class FormBuilder extends Component {
   }
 
   /**
-   * Execute the form submit
-   * @param {Event} e
-   */
-  _handleSubmit = e => {
-    e.preventDefault()
-    this.setState({showErrors: true})
-    this.props.onSubmit(this.state)
-  }
-
-  /**
    * Render method that maps config KEYS and generates form fields dynamically depending on the config, a specific type of form field (select, button group, text-area, etc.)
    */
   render() {
     return (
       <div className={BASE_CLASS}>
-        <form className={FORM_WRAP_CLASS} onSubmit={this._handleSubmit}>
-          {this._formFields.map((field, index) =>
-            this._renderFormField(field, index)
-          )}
-          <AtomButtom isSubmit>{this._submitText}</AtomButtom>
-        </form>
+        {this._formFields.map((field, index) =>
+          this._renderFormField(field, index)
+        )}
       </div>
     )
   }
@@ -384,12 +378,13 @@ FormBuilder.propTypes = {
   }),
   /** Function executed on component load. May be used to intialize form data */
   onLoad: PropTypes.func.isRequired,
-  /** Function executed on field change. May be used to initialize next field data */
-  onChange: PropTypes.func.isRequired,
-  /** Function that sends the form data */
-  onSubmit: PropTypes.func.isRequired,
-  /** Submit button text */
-  submitText: PropTypes.string.isRequired
+  /** Function executed on select field change. May be used to initialize next field data */
+  onSelect: PropTypes.func.isRequired,
+  /** Function executed on input field change. */
+  onInputChange: PropTypes.func.isRequired,
+  /** Get the submit state of the form */
+  isSubmited: PropTypes.bool,
+  onError: PropTypes.func
 }
 
 export default FormBuilder

--- a/components/form/builder/src/index.scss
+++ b/components/form/builder/src/index.scss
@@ -4,16 +4,9 @@
 @import '~@s-ui/react-molecule-select-field/lib/index';
 @import '~@s-ui/react-molecule-textarea-field/lib/index';
 @import '~@s-ui/react-molecule-button-group/lib/index';
-@import '~@schibstedspain/sui-atom-button/lib/index';
 @import '~@s-ui/react-molecule-dropdown-option/lib/index';
 
 .sui-FormBuilder {
-  &-wrap {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-  }
-
   &-item {
     margin-bottom: $m-l;
 

--- a/components/form/builder/src/validatorHoC/WithValidator.js
+++ b/components/form/builder/src/validatorHoC/WithValidator.js
@@ -12,8 +12,8 @@ const getErrorText = ({empty, notAllowed}, value) => {
 }
 
 const WithValidator = BaseComponent => {
-  const FormField = ({errors, showErrors, value, ...rest}) => {
-    const errorText = (showErrors || value) && getErrorText(errors, value)
+  const FormField = ({errors, isSubmited, value, ...rest}) => {
+    const errorText = (isSubmited || value) && getErrorText(errors, value)
     return <BaseComponent {...rest} errorText={errorText} value={value} />
   }
 
@@ -22,7 +22,7 @@ const WithValidator = BaseComponent => {
   FormField.propTypes = {
     type: PropTypes.string,
     errors: PropTypes.Object,
-    showErrors: PropTypes.bool,
+    isSubmited: PropTypes.bool,
     value: PropTypes.string
   }
   return FormField


### PR DESCRIPTION
> Now, the component is no longer responsible for managing the submit of the form.
This is because for product needs, we are forced to add the login component and others with user data, between the form and the submit button.
For this reason, the management of errors, we must also perform in the wrapper component, to prevent the action of sending data if any field contains an error.