### PR TITLE
Feat/move to function and remove deprecated require ensure

### DIFF
--- a/components/services/markdown/package.json
+++ b/components/services/markdown/package.json
@@ -9,6 +9,7 @@
     "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
   },
   "dependencies": {
+    "@schibstedspain/sui-react-hooks": "1",
     "@s-ui/component-dependencies": "1",
     "marked": "0.4.0"
   },

--- a/components/services/markdown/package.json
+++ b/components/services/markdown/package.json
@@ -9,7 +9,6 @@
     "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
   },
   "dependencies": {
-    "@schibstedspain/sui-react-hooks": "1",
     "@s-ui/component-dependencies": "1",
     "marked": "0.4.0"
   },

--- a/components/services/markdown/src/index.js
+++ b/components/services/markdown/src/index.js
@@ -1,5 +1,4 @@
 import React, {useEffect, useState} from 'react'
-import {useMount} from '@schibstedspain/sui-react-hooks'
 import PropTypes from 'prop-types'
 
 const STATUS_OK = 200
@@ -9,20 +8,23 @@ function ServiceMarkdown({src}) {
   const [html, setHtml] = useState('')
   const [loaded, setLoaded] = useState(false)
 
-  useMount(function() {
-    import(/* webpackChunkName: "marked" */ 'marked').then(markedLibrary => {
-      const {default: marked} = markedLibrary
-      const req = new window.XMLHttpRequest()
-      req.open('GET', src, true)
-      req.onload = () => {
-        if (req.readyState === COMPLETED && req.status === STATUS_OK) {
-          setHtml(marked(req.responseText))
-          setLoaded(true)
+  useEffect(
+    function() {
+      import(/* webpackChunkName: "marked" */ 'marked').then(markedLibrary => {
+        const {default: marked} = markedLibrary
+        const req = new window.XMLHttpRequest()
+        req.open('GET', src, true)
+        req.onload = () => {
+          if (req.readyState === COMPLETED && req.status === STATUS_OK) {
+            setHtml(marked(req.responseText))
+            setLoaded(true)
+          }
         }
-      }
-      req.send(null)
-    })
-  })
+        req.send(null)
+      })
+    },
+    [src]
+  )
 
   useEffect(
     function() {

--- a/demo/services/markdown/playground
+++ b/demo/services/markdown/playground
@@ -1,1 +1,1 @@
-return (<ServiceMarkdown src="https://raw.githubusercontent.com/SUI-Components/sui-components/master/demo/services/markdown/example.md"/>)
+return (<ServiceMarkdown src="https://raw.githubusercontent.com/SUI-Components/schibsted-spain-components/master/demo/services/markdown/example.md"/>)


### PR DESCRIPTION
Remove deprecated require.ensure not longer compatible with Webpack 5.
Move to hooks ↩️.
Fix demo.