### PR TITLE
fix(abtesting/hooks): fix experiment context tests by conditionally loading absolute/relative import

### DIFF
--- a/components/abtesting/hooks/src/useExperiment/index.js
+++ b/components/abtesting/hooks/src/useExperiment/index.js
@@ -1,5 +1,6 @@
 import {useContext} from 'react'
 import {ExperimentContext} from '@s-ui/abtesting-optimizely-x'
+import {ExperimentContext as TestExperimentContext} from '../../../optimizelyXExperiment/src'
 
 // Fallback object in case the hook is used in some point of the hierarchy
 // that is not wrapped by OptimizelyXExperiment component (which is the
@@ -11,5 +12,6 @@ const NON_WRAPPED_BY_CONTEXT_PROVIDER_FALLBACK_OBJECT = {
 }
 
 export default () =>
-  useContext(ExperimentContext) ||
-  NON_WRAPPED_BY_CONTEXT_PROVIDER_FALLBACK_OBJECT
+  useContext(
+    process.env.NODE_ENV === 'test' ? TestExperimentContext : ExperimentContext
+  ) || NON_WRAPPED_BY_CONTEXT_PROVIDER_FALLBACK_OBJECT

--- a/components/abtesting/hooks/src/useExperiment/index.js
+++ b/components/abtesting/hooks/src/useExperiment/index.js
@@ -1,6 +1,16 @@
 import {useContext} from 'react'
-import {ExperimentContext} from '@s-ui/abtesting-optimizely-x'
-import {ExperimentContext as TestExperimentContext} from '../../../optimizelyXExperiment/src'
+import {ExperimentContext as ExperimentContextFromPackage} from '@s-ui/abtesting-optimizely-x'
+
+// Use the suitable context depending on the environment
+let ExperimentContext
+if (process.env.NODE_ENV === 'test') {
+  const {
+    ExperimentContext: ExperimentContextFromRelativePath
+  } = require('../../../optimizelyXExperiment/src')
+  ExperimentContext = ExperimentContextFromRelativePath
+} else {
+  ExperimentContext = ExperimentContextFromPackage
+}
 
 // Fallback object in case the hook is used in some point of the hierarchy
 // that is not wrapped by OptimizelyXExperiment component (which is the
@@ -12,6 +22,5 @@ const NON_WRAPPED_BY_CONTEXT_PROVIDER_FALLBACK_OBJECT = {
 }
 
 export default () =>
-  useContext(
-    process.env.NODE_ENV === 'test' ? TestExperimentContext : ExperimentContext
-  ) || NON_WRAPPED_BY_CONTEXT_PROVIDER_FALLBACK_OBJECT
+  useContext(ExperimentContext) ||
+  NON_WRAPPED_BY_CONTEXT_PROVIDER_FALLBACK_OBJECT

--- a/components/abtesting/optimizelyXExperiment/src/index.js
+++ b/components/abtesting/optimizelyXExperiment/src/index.js
@@ -88,8 +88,14 @@ class AbTestOptimizelyXExperiment extends Component {
     }, {})
   }
 
-  _activationHandler = variationId => {
+  _activationHandler = rawVariationId => {
+    const variationId = this._parseVariationId(rawVariationId)
     return this.setState(this._buildContextState({variationId, active: true}))
+  }
+
+  _parseVariationId = rawVariationId => {
+    const numberVariationId = Number(rawVariationId)
+    return !isNaN(numberVariationId) ? numberVariationId : rawVariationId
   }
 
   componentDidMount() {


### PR DESCRIPTION
## Description

- [x] 🐞 Fixes tests*
- [x] 🐞 Adds method to parse raw variationId from optimizely to a number, because it's received as a string.

\* In order for both test and production environments to work with the new experiment context, we need to make sure that `createContext()` is "the same one". This is a temporary solution to fix tests, but we'll need a solution which probably involves moving the experiment context into an isolated package.