### PR TITLE
feat(script/loader): load styles

### DIFF
--- a/components/script/loader/README.md
+++ b/components/script/loader/README.md
@@ -20,7 +20,10 @@ $ npm install @schibstedspain/sui-script-loader --save
 ```js
 import ScriptLoader from '@schibstedspain/sui-script-loader'
 
-return (<ScriptLoader src={src} verifier={() => true} isAsync={false} render={() => 'Ready to render!'} />)
+const src = 'javascript file url'
+const styles = 'styles file url'
+
+return (<ScriptLoader src={src} verifier={() => true} isAsync={false} render={() => 'Ready to render!'} styles={styles}/>)
 ```
 
 **Find full description and more examples in the [demo page](https://sui-components.now.sh/workbench/script/loader).**

--- a/components/script/loader/README.md
+++ b/components/script/loader/README.md
@@ -21,9 +21,9 @@ $ npm install @schibstedspain/sui-script-loader --save
 import ScriptLoader from '@schibstedspain/sui-script-loader'
 
 const src = 'javascript file url'
-const styles = 'styles file url'
+const stylesheet = 'stylesheet file url'
 
-return (<ScriptLoader src={src} verifier={() => true} isAsync={false} render={() => 'Ready to render!'} styles={styles}/>)
+return (<ScriptLoader src={src} verifier={() => true} isAsync={false} render={() => 'Ready to render!'} stylesheet={stylesheet}/>)
 ```
 
 **Find full description and more examples in the [demo page](https://sui-components.now.sh/workbench/script/loader).**

--- a/components/script/loader/package.json
+++ b/components/script/loader/package.json
@@ -9,7 +9,8 @@
     "build:styles": "../../../node_modules/.bin/cpx './src/**/*.scss' ./lib"
   },
   "dependencies": {
-    "@s-ui/component-dependencies": "1"
+    "@s-ui/component-dependencies": "1",
+    "@schibstedspain/sui-react-hooks": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/script/loader/src/helper.js
+++ b/components/script/loader/src/helper.js
@@ -7,7 +7,7 @@ const scriptPromises = []
  * @param  {bool} isAsync
  * @return {Promise}
  */
-const loadScript = ({src, verifier, isAsync, detectionDelay}) => {
+const loadScript = ({src, verifier, isAsync, detectionDelay, styles}) => {
   scriptPromises[src] =
     scriptPromises[src] ||
     new Promise((resolve, reject) => {
@@ -19,6 +19,7 @@ const loadScript = ({src, verifier, isAsync, detectionDelay}) => {
       }
 
       injectScript({src, isAsync})
+      styles && injectStyles({styles})
       waitUntil(verifier, resolve, reject, detectionDelay)
     })
 
@@ -38,6 +39,20 @@ const injectScript = ({src, isAsync}) => {
   script.async = isAsync
 
   document.body.appendChild(script)
+}
+
+/**
+ * Injects the styles file into the head.
+ * @param  {string} styles
+ * @return {void}
+ */
+const injectStyles = ({styles}) => {
+  const link = document.createElement('link')
+
+  link.rel = 'stylesheet'
+  link.href = styles
+
+  document.head.appendChild(link)
 }
 
 /**

--- a/components/script/loader/src/helper.js
+++ b/components/script/loader/src/helper.js
@@ -7,7 +7,7 @@ const scriptPromises = []
  * @param  {bool} isAsync
  * @return {Promise}
  */
-const loadScript = ({src, verifier, isAsync, detectionDelay, styles}) => {
+const loadScript = ({src, verifier, isAsync, detectionDelay, stylesheet}) => {
   scriptPromises[src] =
     scriptPromises[src] ||
     new Promise((resolve, reject) => {
@@ -19,7 +19,7 @@ const loadScript = ({src, verifier, isAsync, detectionDelay, styles}) => {
       }
 
       injectScript({src, isAsync})
-      styles && injectStyles({styles})
+      stylesheet && injectStyles(stylesheet)
       waitUntil(verifier, resolve, reject, detectionDelay)
     })
 
@@ -46,11 +46,11 @@ const injectScript = ({src, isAsync}) => {
  * @param  {string} styles
  * @return {void}
  */
-const injectStyles = ({styles}) => {
+const injectStyles = stylesheet => {
   const link = document.createElement('link')
 
   link.rel = 'stylesheet'
-  link.href = styles
+  link.href = stylesheet
 
   document.head.appendChild(link)
 }

--- a/components/script/loader/src/index.js
+++ b/components/script/loader/src/index.js
@@ -9,9 +9,16 @@ class ScriptLoader extends Component {
   }
 
   componentDidMount() {
-    const {src, verifier, isAsync, detectionDelay, onTimeout} = this.props
+    const {
+      src,
+      verifier,
+      isAsync,
+      detectionDelay,
+      onTimeout,
+      styles
+    } = this.props
 
-    loadScript({src, verifier, isAsync, detectionDelay})
+    loadScript({src, verifier, isAsync, detectionDelay, styles})
       .then(() => this.setState({readyToRender: true}))
       .catch(() => this.setState({timeout: true}, onTimeout))
   }
@@ -58,7 +65,12 @@ ScriptLoader.propTypes = {
   /**
    * Detection delay time (in miliseconds)
    */
-  detectionDelay: PropTypes.number
+  detectionDelay: PropTypes.number,
+
+  /**
+   * Styles to be injected
+   */
+  styles: PropTypes.string
 }
 
 ScriptLoader.defaultProps = {

--- a/components/script/loader/src/index.js
+++ b/components/script/loader/src/index.js
@@ -1,36 +1,33 @@
-import {Component} from 'react'
+import {useEffect, useState} from 'react'
+import {useMount} from '@schibstedspain/sui-react-hooks'
 import PropTypes from 'prop-types'
 import {loadScript} from './helper.js'
 
-class ScriptLoader extends Component {
-  state = {
-    readyToRender: false,
-    timeout: false
-  }
+const ScriptLoader = ({
+  src,
+  verifier,
+  isAsync = true,
+  detectionDelay = 5000,
+  onTimeout = () => {},
+  stylesheet,
+  render,
+  timeoutRender = () => null
+}) => {
+  const [readyToRender, setReadyToRender] = useState(false)
+  const [timeout, seTimeout] = useState(false)
 
-  componentDidMount() {
-    const {
-      src,
-      verifier,
-      isAsync,
-      detectionDelay,
-      onTimeout,
-      stylesheet
-    } = this.props
-
+  const initLoad = () => {
     loadScript({src, verifier, isAsync, detectionDelay, stylesheet})
-      .then(() => this.setState({readyToRender: true}))
-      .catch(() => this.setState({timeout: true}, onTimeout))
+      .then(() => setReadyToRender(true))
+      .catch(() => seTimeout(true))
   }
 
-  render() {
-    const {render, timeoutRender} = this.props
-    const {readyToRender, timeout} = this.state
+  useEffect(() => onTimeout(), [onTimeout, timeout])
+  useMount(initLoad)
 
-    if (readyToRender && render) return render()
-    if (timeout && timeoutRender) return timeoutRender()
-    return null
-  }
+  if (readyToRender && render) return render()
+  if (timeout && timeoutRender) return timeoutRender()
+  return null
 }
 
 ScriptLoader.displayName = 'ScriptLoader'
@@ -71,13 +68,6 @@ ScriptLoader.propTypes = {
    * Stylesheet to be injected
    */
   stylesheet: PropTypes.string
-}
-
-ScriptLoader.defaultProps = {
-  isAsync: true,
-  onTimeout: () => {},
-  timeoutRender: () => null,
-  detectionDelay: 5000
 }
 
 export default ScriptLoader

--- a/components/script/loader/src/index.js
+++ b/components/script/loader/src/index.js
@@ -15,10 +15,10 @@ class ScriptLoader extends Component {
       isAsync,
       detectionDelay,
       onTimeout,
-      styles
+      stylesheet
     } = this.props
 
-    loadScript({src, verifier, isAsync, detectionDelay, styles})
+    loadScript({src, verifier, isAsync, detectionDelay, stylesheet})
       .then(() => this.setState({readyToRender: true}))
       .catch(() => this.setState({timeout: true}, onTimeout))
   }
@@ -68,9 +68,9 @@ ScriptLoader.propTypes = {
   detectionDelay: PropTypes.number,
 
   /**
-   * Styles to be injected
+   * Stylesheet to be injected
    */
-  styles: PropTypes.string
+  stylesheet: PropTypes.string
 }
 
 ScriptLoader.defaultProps = {

--- a/demo/script/loader/playground
+++ b/demo/script/loader/playground
@@ -43,7 +43,7 @@ return (
     <p>
       <ScriptLoader
         src="https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/3.0.0/adyen.js"
-        styles="https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/3.0.0/adyen.css"
+        stylesheet="https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/3.0.0/adyen.css"
         isAsync
         verifier={() => window && window.AdyenCheckout}
         render={() => 'Adyen script and styles loaded!'}

--- a/demo/script/loader/playground
+++ b/demo/script/loader/playground
@@ -31,6 +31,7 @@ return (
         timeoutRender={() => 'I\'d rather prefer to not to load jQuery :P'}
       />
     </p>
+
     <p>
       <ScriptLoader
         src='https://connect.facebook.net/es_ES/sdk.js'

--- a/demo/script/loader/playground
+++ b/demo/script/loader/playground
@@ -39,5 +39,14 @@ return (
         render={() => 'Facebook SDK loaded!'}
       />
     </p>
+    <p>
+      <ScriptLoader
+        src="https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/3.0.0/adyen.js"
+        styles="https://checkoutshopper-test.adyen.com/checkoutshopper/sdk/3.0.0/adyen.css"
+        isAsync
+        verifier={() => window && window.AdyenCheckout}
+        render={() => 'Adyen script and styles loaded!'}
+      />
+    </p>
   </div>
 )


### PR DESCRIPTION
Some scripts need to load styles in order to work properly, so let's add a `styles` prop and inject it in the document `head`.

EDIT:

besides that, I did a full component refactor:

- moving deprecated default proptypes to deconstruction default values
- converting class into function
- use hooks (useState, useMount, useEffect)