### PR TITLE
Fix/experiment context by using dependency injection approach in tests

### DIFF
--- a/components/abtesting/hooks/src/useExperiment/index.js
+++ b/components/abtesting/hooks/src/useExperiment/index.js
@@ -1,17 +1,6 @@
 import {useContext} from 'react'
 import {ExperimentContext as ExperimentContextFromPackage} from '@s-ui/abtesting-optimizely-x'
 
-// Use the suitable context depending on the environment
-let ExperimentContext
-if (process.env.NODE_ENV === 'test') {
-  const {
-    ExperimentContext: ExperimentContextFromRelativePath
-  } = require('../../../optimizelyXExperiment/src')
-  ExperimentContext = ExperimentContextFromRelativePath
-} else {
-  ExperimentContext = ExperimentContextFromPackage
-}
-
 // Fallback object in case the hook is used in some point of the hierarchy
 // that is not wrapped by OptimizelyXExperiment component (which is the
 // provider of the actual context). This way we mainly avoid trying to access
@@ -21,6 +10,6 @@ const NON_WRAPPED_BY_CONTEXT_PROVIDER_FALLBACK_OBJECT = {
   isWrapped: false
 }
 
-export default () =>
-  useContext(ExperimentContext) ||
+export default ({ExperimentContext} = {}) =>
+  useContext(ExperimentContext || ExperimentContextFromPackage) ||
   NON_WRAPPED_BY_CONTEXT_PROVIDER_FALLBACK_OBJECT

--- a/components/abtesting/optimizelyXExperiment/test/advanced.test.js
+++ b/components/abtesting/optimizelyXExperiment/test/advanced.test.js
@@ -2,17 +2,19 @@
 import React from 'react'
 import Enzyme, {shallow} from 'enzyme'
 import OptimizelyX from '../src/optimizely-x'
-import AbTestOptimizelyXExperiment from '../src/index'
+import AbTestOptimizelyXExperiment, {ExperimentContext} from '../src/index'
 import {useExperiment} from '../../hooks/src/index'
 import Adapter from 'enzyme-adapter-react-16'
 
 Enzyme.configure({adapter: new Adapter()})
 
+const HOOK_PARAMS = {ExperimentContext}
+
 describe('useExperiment', () => {
   describe('when the component IS NOT wrapped by an experiment component', () => {
     it('should output isWrapped to false', () => {
       const Child = () => {
-        const {isWrapped} = useExperiment()
+        const {isWrapped} = useExperiment(HOOK_PARAMS)
         return isWrapped.toString()
       }
       const component = (
@@ -25,7 +27,7 @@ describe('useExperiment', () => {
     })
     it('should output isDefault to true', () => {
       const Child = () => {
-        const {isDefault} = useExperiment()
+        const {isDefault} = useExperiment(HOOK_PARAMS)
         return isDefault.toString()
       }
       const component = (
@@ -54,7 +56,7 @@ describe('useExperiment', () => {
 
     it('should output isWrapped to true, then keep isWrapped to true', () => {
       const Child = () => {
-        const {isWrapped} = useExperiment()
+        const {isWrapped} = useExperiment(HOOK_PARAMS)
         return isWrapped.toString()
       }
       const component = (
@@ -73,7 +75,7 @@ describe('useExperiment', () => {
 
     it('should output isActive to false, then set isActive to true', () => {
       const Child = () => {
-        const {isActive} = useExperiment()
+        const {isActive} = useExperiment(HOOK_PARAMS)
         return isActive.toString()
       }
       const component = (
@@ -92,7 +94,7 @@ describe('useExperiment', () => {
 
     it('should output isDefault to true, then set isDefault to false', () => {
       const Child = () => {
-        const {isDefault} = useExperiment()
+        const {isDefault} = useExperiment(HOOK_PARAMS)
         return isDefault.toString()
       }
       const component = (
@@ -111,7 +113,7 @@ describe('useExperiment', () => {
 
     it('should output isVariation to false, then set isVariation to true', () => {
       const Child = () => {
-        const {isVariation} = useExperiment()
+        const {isVariation} = useExperiment(HOOK_PARAMS)
         return isVariation.toString()
       }
       const component = (
@@ -130,7 +132,7 @@ describe('useExperiment', () => {
 
     it('should contain parent experimentId and choosen variationId, then keep experimentId and set variationId to the choosen one', () => {
       const Child = () => {
-        const {experimentId, variationId} = useExperiment()
+        const {experimentId, variationId} = useExperiment(HOOK_PARAMS)
         return `${experimentId}/${variationId}`
       }
       const component = (
@@ -149,7 +151,7 @@ describe('useExperiment', () => {
 
     it('should match default variation in variationName, then match the choosen variation in variationName', () => {
       const Child = () => {
-        const {variationName} = useExperiment()
+        const {variationName} = useExperiment(HOOK_PARAMS)
         return variationName
       }
       const component = (
@@ -167,7 +169,9 @@ describe('useExperiment', () => {
 
     it('should match default variation in variation flags, then match the choosen variation in variation flags', () => {
       const Child = () => {
-        const {isVariationA, isVariationB, isVariationC} = useExperiment()
+        const {isVariationA, isVariationB, isVariationC} = useExperiment(
+          HOOK_PARAMS
+        )
         return `${isVariationA}:${isVariationB}:${isVariationC}`
       }
       const component = (
@@ -185,7 +189,7 @@ describe('useExperiment', () => {
 
     it('should always keep forceVariation when provided as an id', () => {
       const Child = () => {
-        const {variationName} = useExperiment()
+        const {variationName} = useExperiment(HOOK_PARAMS)
         return variationName
       }
       const component = (
@@ -206,7 +210,7 @@ describe('useExperiment', () => {
 
     it('should always keep forceVariation when provided as a name', () => {
       const Child = () => {
-        const {variationName} = useExperiment()
+        const {variationName} = useExperiment(HOOK_PARAMS)
         return variationName
       }
       const component = (


### PR DESCRIPTION
## Issue

📦 Only the new `@s-ui/abtesting-hooks` package is affected.

`npm run build:server` throws an error on web-server when using useExperiment hook, no matter what value `process.env.NODE_ENV` is. So the previous fix #96 is meaningless for this scenario (the part of env checking I mean). `npm run dev` is totally OK, though.

```
> node ./scripts/compileServer

../node_modules/@s-ui/abtesting-hooks/lib/useExperiment/index.js
Module not found: Error: Can't resolve '../../../optimizelyXExperiment/src' in ...
```

## Solution

Dependency injection approach!

That is, do the relative import of ExperimentContext in the tests file (just where it's needed) and pass it to the useExperiment hook in order to override the one that comes from the package.

- ✅ Tests working.
- ✅ No import errors in any scenario.