### PR TITLE
Feature/add force activation props to optimizely x experiment

### DIFF
--- a/components/abtesting/optimizelyXExperiment/README.md
+++ b/components/abtesting/optimizelyXExperiment/README.md
@@ -148,6 +148,28 @@ In the above example, "Dogs" variation will be always displayed. You can also us
 
 NOTE: Since this prop is meant to be used in development environment only, forceVariation is just ignored in production as a preventive measure.
 
+### forceActivation (for development purposes)
+
+This prop is similar to `forceVariation` prop, but it simulates an actual activation, so default variation is displayed first and then it gets swapped by the passed variation after X milliseconds (the number of milliseconds can be changed via `forceActivationDelay` prop). This is the closest behaviour to an actual experiment that you could configure in Optimizely's panel because you get the same "flash" effect. This way you can check that nothing gets broken despite the flash, without the need of actually configuring an experiment in Optimizely's panel.
+
+```html
+<OptimizelyXExperiment experimentId={8470306415} forceActivation={8480321136}>
+  <button variationId={8463707014} defaultVariation>Cats</button>
+  <button variationId={8480321136}>Dogs</button>
+</OptimizelyXExperiment>
+```
+
+In the above example, "Cats" variation will be displayed first, then after a few milliseconds "Dogs" variation will be definitely displayed. You can also use variation name instead:
+
+```html
+<OptimizelyXExperiment experimentId={8470306415} forceActivation="B">
+  <button variationId={8463707014} defaultVariation>Cats</button>
+  <button variationId={8480321136}>Dogs</button>
+</OptimizelyXExperiment>
+```
+
+NOTE: Since this prop is meant to be used in development environment only, forceVariation is just ignored in production as a preventive measure.
+
 ## Known issues
 
 ### Clipping of variations

--- a/components/abtesting/optimizelyXExperiment/test/advanced.test.js
+++ b/components/abtesting/optimizelyXExperiment/test/advanced.test.js
@@ -7,6 +7,7 @@ import {useExperiment} from '../../hooks/src/index'
 import Adapter from 'enzyme-adapter-react-16'
 
 Enzyme.configure({adapter: new Adapter()})
+jest.useFakeTimers()
 
 const HOOK_PARAMS = {ExperimentContext}
 
@@ -223,6 +224,45 @@ describe('useExperiment', () => {
       const mounted = shallow(component)
       expect(mounted.html()).toEqual('B')
       activationHandler(700002)
+      expect(mounted.html()).toEqual('B')
+    })
+
+    it('should display default variation first, then display forceActivation after a few milliseconds when provided as an id', () => {
+      const Child = () => {
+        const {variationName} = useExperiment(HOOK_PARAMS)
+        return variationName
+      }
+      const component = (
+        <AbTestOptimizelyXExperiment
+          experimentId={40000}
+          forceActivation={700001} // B
+        >
+          <Child defaultVariation variationId={700000} />
+          <Child variationId={700001} />
+          <Child variationId={700002} />
+        </AbTestOptimizelyXExperiment>
+      )
+      const mounted = shallow(component)
+      expect(mounted.html()).toEqual('A')
+      jest.runAllTimers()
+      expect(mounted.html()).toEqual('B')
+    })
+
+    it('should display default variation first, then display forceActivation after a few milliseconds when provided as a name', () => {
+      const Child = () => {
+        const {variationName} = useExperiment(HOOK_PARAMS)
+        return variationName
+      }
+      const component = (
+        <AbTestOptimizelyXExperiment experimentId={40000} forceActivation="B">
+          <Child defaultVariation variationId={700000} />
+          <Child variationId={700001} />
+          <Child variationId={700002} />
+        </AbTestOptimizelyXExperiment>
+      )
+      const mounted = shallow(component)
+      expect(mounted.html()).toEqual('A')
+      jest.runAllTimers()
       expect(mounted.html()).toEqual('B')
     })
   })


### PR DESCRIPTION
## ✍️ Description

Adds the following new props to improve the developer experience regarding to variations testing:

- `forceActivation`: A variation id or name. It will force the `_activationHandler` method to be ran for the passed variation after a few milliseconds.
- `forceActivationDelay`: Number of milliseconds after which a "forced activation" will happen. Already has a default value in milliseconds.

The new `forceActivation` prop works in a similar way to `forceVariation` prop. The difference is, as the new docs stand, that an actual activation is done, which means the default variation is actually displayed first and then swapped by the intended one.

This is the closest behaviour to an actual experiment that you could configure in Optimizely's panel because you get the same "flash" effect. This way you can check that nothing gets broken despite the flash, without the need of actually configuring an experiment in Optimizely's panel.

## ☑️ Tasks

- [x] Add `forceActivation` prop.
- [x] Add `forceActivationDelay` prop.
- [x] Add docs.
- [x] Add tests.