### PR TITLE
fix(react/hooks): make sure legacy state hook extends the most updated state

### DIFF
--- a/components/react/hooks/src/useLegacyState/index.js
+++ b/components/react/hooks/src/useLegacyState/index.js
@@ -2,6 +2,7 @@ import {useState} from 'react'
 
 export default function useLegacyState(initialState = {}) {
   const [state, setState] = useState(initialState)
-  const setLegacyState = newState => setState({...state, ...newState})
+  const setLegacyState = newState =>
+    setState(prevState => ({...prevState, ...newState}))
   return [state, setLegacyState]
 }


### PR DESCRIPTION
## ✍️ Description

Inner `useState` in `useLegacyState` produces a race condition if two `setLegacyState` are run very closely, so the previous update could be lost. This is not how the legacy `this.setState` method actually works.

After a few minutes taking a look at it with @midudev we solved this by passing a function to `useState` instead, so we ensure that the object we extend the state from will always be the most updated one.