### PR TITLE
fix(cmp/ui): remove banner icon prop

### DIFF
--- a/components/cmp/ui/src/CmpUiBanner/index.js
+++ b/components/cmp/ui/src/CmpUiBanner/index.js
@@ -29,7 +29,6 @@ export default function CmpBanner({lang, onAccept, onConfigure}) {
     <div className={CLASS}>
       <Notification
         autoClose="manual"
-        icon={() => {}}
         position="bottom"
         show
         showCloseButton={false}

--- a/components/cmp/ui/src/CmpUiBanner/index.js
+++ b/components/cmp/ui/src/CmpUiBanner/index.js
@@ -7,6 +7,8 @@ import Button from '@schibstedspain/sui-atom-button'
 
 import {CLASS, I18N} from '../settings'
 
+const EmptyIcon = () => null
+
 export default function CmpBanner({lang, onAccept, onConfigure}) {
   const textRef = useRef()
 
@@ -29,6 +31,7 @@ export default function CmpBanner({lang, onAccept, onConfigure}) {
     <div className={CLASS}>
       <Notification
         autoClose="manual"
+        icon={<EmptyIcon />}
         position="bottom"
         show
         showCloseButton={false}


### PR DESCRIPTION
fix demo warning:

```
main.js:41046 Warning: Failed prop type: Invalid prop `icon` supplied to `MoleculeNotification`, expected a ReactNode.
    in MoleculeNotification (created by CmpBanner)
    in CmpBanner (created by CmpUiContainer)
    in Suspense (created by CmpUiContainer)
    in div (created by CmpUiContainer)
    in CmpUiContainer (created by CmpServices)
    in CmpServices (created by CmpUi)
    in CmpUi
    in div
console.<computed> @ main.js:41046
main.js:41046 Warning: Functions are not valid as a React child. This may happen if you return a Component instead of <Component /> from render. Or maybe you meant to call this function rather than return it.
    in span (created by MoleculeNotification)
    in div (created by MoleculeNotification)
    in div (created by MoleculeNotification)
    in div (created by MoleculeNotification)
    in MoleculeNotification (created by CmpBanner)
    in div (created by CmpBanner)
    in CmpBanner (created by CmpUiContainer)
    in Suspense (created by CmpUiContainer)
    in div (created by CmpUiContainer)
    in CmpUiContainer (created by CmpServices)
    in CmpServices (created by CmpUi)
    in CmpUi
    in div
```