### PR TITLE
feat(section/info): add withoutBorder prop

### DIFF
--- a/components/section/info/src/index.js
+++ b/components/section/info/src/index.js
@@ -6,13 +6,15 @@ const baseClass = 'sui-SectionInfo'
 const baseContentClass = `${baseClass}-content`
 const titleClass = `${baseClass}-title`
 
-export default function SectionInfo({title, children}) {
+export default function SectionInfo({title, children, withoutBorder}) {
   const contentClass = cx(baseContentClass, {
     [`${baseContentClass}--withoutTitle`]: !title
   })
 
   return (
-    <section className={baseClass}>
+    <section
+      className={cx(baseClass, withoutBorder && `${baseClass}--withoutBorder`)}
+    >
       {title && <h3 className={titleClass}>{title}</h3>}
       <div className={contentClass}>{children}</div>
     </section>
@@ -27,5 +29,6 @@ SectionInfo.propTypes = {
     PropTypes.string,
     PropTypes.element,
     PropTypes.object
-  ])
+  ]),
+  withoutBorder: PropTypes.bool
 }

--- a/components/section/info/src/index.scss
+++ b/components/section/info/src/index.scss
@@ -14,6 +14,10 @@
   max-width: $mw-section-info;
   padding: $p-xxl 0;
 
+  &--withoutBorder {
+    border-bottom: none;
+  }
+
   &-title {
     @include media-breakpoint-down(m) {
       flex-basis: auto;

--- a/demo/section/info/playground
+++ b/demo/section/info/playground
@@ -1,27 +1,47 @@
-const descriptionElement = <p>Spicy jalapeno bacon ipsum dolor amet pig short ribs pork chop, pork belly sausage rump meatball brisket shoulder. Drumstick jowl filet mignon, turducken rump cupim pork loin frankfurter tri-tip meatball porchetta cow kevin. Leberkas drumstick jowl ground round short ribs pork. Meatloaf shank meatball pork belly, corned beef frankfurter spare ribs tenderloin flank short ribs porchetta pork chop ground round burgdoggen. Tri-tip salami meatloaf, beef ribs buffalo cupim sirloin chicken tenderloin doner andouille picanha bresaola ham. Strip steak bresaola pork chop, short loin shank shankle ham hock ribeye turducken spare ribs chicken bacon landjaeger.</p>
+/* eslint-disable react/react-in-jsx-scope, react/jsx-no-undef */
+const longText =
+  'Spicy jalapeno bacon ipsum dolor amet pig short ribs pork chop, pork belly sausage rump meatball brisket shoulder. Drumstick jowl filet mignon, turducken rump cupim pork loin frankfurter tri-tip meatball porchetta cow kevin. Leberkas drumstick jowl ground round short ribs pork. Meatloaf shank meatball pork belly, corned beef frankfurter spare ribs tenderloin flank short ribs porchetta pork chop ground round burgdoggen. Tri-tip salami meatloaf, beef ribs buffalo cupim sirloin chicken tenderloin doner andouille picanha bresaola ham. Strip steak bresaola pork chop, short loin shank shankle ham hock ribeye turducken spare ribs chicken bacon landjaeger.'
+
+const descriptionElement = <p>{longText}</p>
 const description = 'Description'
 
 const extras = 'Extras'
-const extrasElement = <ul><li>air conditioning</li><li>lifter</li><li>terace</li><li>pool</li><li>parking</li><li>solar powered</li><li>kitchen</li><li>toilett</li><li>garden</li><li>appliances</li></ul>
-const extrasElementNoTitle = <p><strong>No title at all</strong> - Spicy jalapeno bacon ipsum dolor amet pig short ribs pork chop, pork belly sausage rump meatball brisket shoulder. Drumstick jowl filet mignon, turducken rump cupim pork loin frankfurter tri-tip meatball porchetta cow kevin. Leberkas drumstick jowl ground round short ribs pork. Meatloaf shank meatball pork belly, corned beef frankfurter spare ribs tenderloin flank short ribs porchetta pork chop ground round burgdoggen. Tri-tip salami meatloaf, beef ribs buffalo cupim sirloin chicken tenderloin doner andouille picanha bresaola ham. Strip steak bresaola pork chop, short loin shank shankle ham hock ribeye turducken spare ribs chicken bacon landjaeger.</p>
-const extrasElementEmptyTitle = <p><strong>A container with empty Title Value</strong> - Spicy jalapeno bacon ipsum dolor amet pig short ribs pork chop, pork belly sausage rump meatball brisket shoulder. Drumstick jowl filet mignon, turducken rump cupim pork loin frankfurter tri-tip meatball porchetta cow kevin. Leberkas drumstick jowl ground round short ribs pork. Meatloaf shank meatball pork belly, corned beef frankfurter spare ribs tenderloin flank short ribs porchetta pork chop ground round burgdoggen. Tri-tip salami meatloaf, beef ribs buffalo cupim sirloin chicken tenderloin doner andouille picanha bresaola ham. Strip steak bresaola pork chop, short loin shank shankle ham hock ribeye turducken spare ribs chicken bacon landjaeger.</p>
+const extrasElement = (
+  <ul>
+    <li>air conditioning</li>
+    <li>lifter</li>
+    <li>terace</li>
+    <li>pool</li>
+    <li>parking</li>
+    <li>solar powered</li>
+    <li>kitchen</li>
+    <li>toilett</li>
+    <li>garden</li>
+    <li>appliances</li>
+  </ul>
+)
+const extrasElementNoTitle = (
+  <p>
+    <strong>No title at all</strong> - {longText}
+  </p>
+)
+const extrasElementEmptyTitle = (
+  <p>
+    <strong>A container with empty Title Value</strong> - {longText}
+  </p>
+)
+const extrasElementNoBorder = (
+  <p>
+    <strong>No border at all</strong> - {longText}
+  </p>
+)
 
 return (
   <div>
-    <SectionInfo title={description}>
-      {descriptionElement}
-    </SectionInfo>
-
-    <SectionInfo title={extras}>
-      {extrasElement}
-    </SectionInfo>
-
-    <SectionInfo title=''>
-      {extrasElementEmptyTitle}
-    </SectionInfo>
-
-    <SectionInfo>
-      {extrasElementNoTitle}
-    </SectionInfo>
+    <SectionInfo title={description}>{descriptionElement}</SectionInfo>
+    <SectionInfo title={extras}>{extrasElement}</SectionInfo>
+    <SectionInfo title="">{extrasElementEmptyTitle}</SectionInfo>
+    <SectionInfo>{extrasElementNoTitle}</SectionInfo>
+    <SectionInfo withoutBorder>{extrasElementNoBorder}</SectionInfo>
   </div>
 )


### PR DESCRIPTION
## Tasks
On the `section/info` component:
- [x] Add new `withoutBorder` prop which removes the border.
- [x] Refactor playground and add a use case on it.