### PR TITLE
fix(cmp/ui): close banner when modal is accepted

### DIFF
--- a/components/cmp/ui/src/CmpUi/index.js
+++ b/components/cmp/ui/src/CmpUi/index.js
@@ -40,6 +40,7 @@ export default function CmpUiContainer({
     setShowNotification(false)
 
     _removeBodyEvent()
+
     onAccept()
   }
 
@@ -64,6 +65,7 @@ export default function CmpUiContainer({
   }
 
   const _handleExitModal = () => {
+    setShowNotification(false)
     setShowModal(false)
   }
 


### PR DESCRIPTION
Fix bug that made notification not to close when modal is accepted.