### PR TITLE
feat(map/basic): add click event for polygon layers

### DIFF
--- a/components/map/basic/src/index.js
+++ b/components/map/basic/src/index.js
@@ -76,6 +76,7 @@ class MapBasic extends Component {
       mapViewModes: this.props.mapViewModes,
       maxZoom: this.props.maxZoom,
       minZoom: this.props.minZoom,
+      onLayerClick: this.props.onLayerClick,
       onPolygonWithBounds: this.props.onPolygonWithBounds,
       polygons: this.props.polygons,
       scrollWheelZoom: this.props.scrollWheelZoom,
@@ -216,6 +217,7 @@ MapBasic.propTypes = {
    * A number used to lock the min zoom or zoom out that a user can do.
    */
   minZoom: PropTypes.number,
+  onLayerClick: PropTypes.func,
   onMapClick: PropTypes.func,
   onMapDragEnd: PropTypes.func,
   onMapLoad: PropTypes.func,
@@ -308,6 +310,7 @@ MapBasic.defaultProps = {
   mapViewModes: [mapViewModes.NORMAL, mapViewModes.SATELLITE],
   maxZoom: 20,
   minZoom: 6,
+  onLayerClick: NO_OP,
   onMapClick: NO_OP,
   onMapDragEnd: NO_OP,
   onMapLoad: NO_OP,

--- a/components/map/basic/src/leaflet/map.js
+++ b/components/map/basic/src/leaflet/map.js
@@ -55,8 +55,19 @@ export default class LeafletMap {
     this.mapDOM = mapDOMInstance
   }
 
-  buildPolygons({hoverStyles, onPolygonWithBounds, polygons, showLabels}) {
-    this.polygons = new Polygons({hoverStyles, onPolygonWithBounds, showLabels})
+  buildPolygons({
+    hoverStyles,
+    onLayerClick,
+    onPolygonWithBounds,
+    polygons,
+    showLabels
+  }) {
+    this.polygons = new Polygons({
+      hoverStyles,
+      onLayerClick,
+      onPolygonWithBounds,
+      showLabels
+    })
     this.polygons.setPolygonsOnMap({map: this._map, polygons})
   }
 

--- a/components/map/basic/src/leaflet/shapes/Polygons.js
+++ b/components/map/basic/src/leaflet/shapes/Polygons.js
@@ -14,8 +14,9 @@ export default class SearchMapPolygons {
 
   BASE_CLASSNAME = 'scm-map__area'
 
-  constructor({hoverStyles, onPolygonWithBounds, showLabels}) {
+  constructor({hoverStyles, onLayerClick, onPolygonWithBounds, showLabels}) {
     this.hoverStyles = hoverStyles
+    this.onLayerClick = onLayerClick
     this.onPolygonWithBounds = onPolygonWithBounds
     this.showLabels = showLabels
   }
@@ -47,7 +48,8 @@ export default class SearchMapPolygons {
             if (!L.Browser.ie && !L.Browser.opera) {
               this.bringToFront()
             }
-          }
+          },
+          click: this.onLayerClick
         })
       }
     })
@@ -58,12 +60,16 @@ export default class SearchMapPolygons {
 
     if (this.showLabels) {
       polygonGeoJSon.eachLayer(function(layer) {
-        layer
-          .bindTooltip(layer.feature.properties.LocationName, {
-            permanent: true,
-            direction: 'center'
-          })
-          .openTooltip()
+        if (!layer?.feature?.properties?.LocationName) return
+
+        try {
+          layer
+            .bindTooltip(layer.feature.properties.LocationName, {
+              permanent: true,
+              direction: 'center'
+            })
+            .openTooltip()
+        } catch (error) {}
       })
     }
 


### PR DESCRIPTION
Adds new `onLayerClick` prop on `map/basic` component which defaults to NO_OP function. This allows to define a click event for all the individual polygons that can be displayed in the map.