### PR TITLE
feat(map/basic): add hover and fit bound class to map basic polygon labels

### DIFF
--- a/components/map/basic/src/leaflet/shapes/Polygons.js
+++ b/components/map/basic/src/leaflet/shapes/Polygons.js
@@ -45,13 +45,13 @@ export default class SearchMapPolygons {
             polygonGeoJSon.resetStyle(this)
 
             const tooltipElement = getTooltipElement(this)
-            tooltipElement.classList.remove('is-hover')
+            if (tooltipElement) tooltipElement.classList.remove('is-hover')
           },
           mouseover: function() {
             this.setStyle(hoverStyles)
 
             const tooltipElement = getTooltipElement(this)
-            tooltipElement.classList.add('is-hover')
+            if (tooltipElement) tooltipElement.classList.add('is-hover')
 
             if (!L.Browser.ie && !L.Browser.opera) {
               this.bringToFront()


### PR DESCRIPTION
Adds the following state classes for tooltip in order to allow applying custom styles:

- `is-hover`
- `is-fit-bound`