### PR TITLE
feat(map/basic): do not show label to our current location

### DIFF
--- a/components/map/basic/src/index.js
+++ b/components/map/basic/src/index.js
@@ -62,6 +62,7 @@ class MapBasic extends Component {
       appCode: this.props.appCode,
       appId: this.props.appId,
       attribution: this.props.attribution,
+      currentGeoCode: this.props.currentGeoCode,
       dragging: this.props.isInteractable,
       enableViewMenu: this.props.enableViewMenu,
       heatMapUrl: this.props.heatMapUrl,
@@ -184,6 +185,7 @@ MapBasic.propTypes = {
    * An array composed by lat and lng like: [lat, lng]
    */
   center: PropTypes.array,
+  currentGeoCode: PropTypes.string,
   /**
    * Heat map url is the source where we are going to get the heatMap layers
    */
@@ -304,6 +306,7 @@ MapBasic.defaultProps = {
   attribution:
     'Map &copy; 1987-2017 <a href="http://developer.here.com">HERE</a>',
   center: [40.00237, -3.99902],
+  currentGeoCode: '',
   id: 'map-container',
   isInteractable: true,
   language: mapLanguages.ENGLISH,

--- a/components/map/basic/src/leaflet/map.js
+++ b/components/map/basic/src/leaflet/map.js
@@ -56,6 +56,7 @@ export default class LeafletMap {
   }
 
   buildPolygons({
+    currentGeoCode,
     hoverStyles,
     onLayerClick,
     onPolygonWithBounds,
@@ -63,6 +64,7 @@ export default class LeafletMap {
     showLabels
   }) {
     this.polygons = new Polygons({
+      currentGeoCode,
       hoverStyles,
       onLayerClick,
       onPolygonWithBounds,

--- a/components/map/basic/src/leaflet/shapes/Polygons.js
+++ b/components/map/basic/src/leaflet/shapes/Polygons.js
@@ -84,9 +84,11 @@ export default class SearchMapPolygons {
           return
 
         try {
-          that.currentGeoCode !== layer.feature.properties.Code &&
+          const {Code, LocationName} = layer.feature.properties
+
+          that.currentGeoCode !== Code &&
             layer
-              .bindTooltip(layer.feature.properties.LocationName, {
+              .bindTooltip(LocationName, {
                 permanent: true,
                 direction: 'center',
                 className: fitBound ? 'is-fit-bound' : ''

--- a/components/map/basic/src/leaflet/shapes/Polygons.js
+++ b/components/map/basic/src/leaflet/shapes/Polygons.js
@@ -14,7 +14,14 @@ export default class SearchMapPolygons {
 
   BASE_CLASSNAME = 'scm-map__area'
 
-  constructor({hoverStyles, onLayerClick, onPolygonWithBounds, showLabels}) {
+  constructor({
+    currentGeoCode,
+    hoverStyles,
+    onLayerClick,
+    onPolygonWithBounds,
+    showLabels
+  }) {
+    this.currentGeoCode = currentGeoCode
     this.hoverStyles = hoverStyles
     this.onLayerClick = onLayerClick
     this.onPolygonWithBounds = onPolygonWithBounds
@@ -67,17 +74,24 @@ export default class SearchMapPolygons {
     polygonGeoJSon.addTo(map)
 
     if (this.showLabels) {
+      const that = this
+
       polygonGeoJSon.eachLayer(function(layer) {
-        if (!layer?.feature?.properties?.LocationName) return
+        if (
+          !layer?.feature?.properties?.LocationName ||
+          !layer?.feature?.properties?.Code
+        )
+          return
 
         try {
-          layer
-            .bindTooltip(layer.feature.properties.LocationName, {
-              permanent: true,
-              direction: 'center',
-              className: fitBound ? 'is-fit-bound' : ''
-            })
-            .openTooltip()
+          that.currentGeoCode !== layer.feature.properties.Code &&
+            layer
+              .bindTooltip(layer.feature.properties.LocationName, {
+                permanent: true,
+                direction: 'center',
+                className: fitBound ? 'is-fit-bound' : ''
+              })
+              .openTooltip()
         } catch (error) {}
       })
     }


### PR DESCRIPTION
## Description

Show label only on children and brothers. Until now, we were showing the label for the current location too.

## Preview

In this example, we removed "El Masnou" label and only show its children.

![image](https://user-images.githubusercontent.com/13108014/64840817-0cd15b80-d5fd-11e9-948e-7710442a41bf.png)
