### PR TITLE
fix(modal/basic): classList.toggle second argument not supported by IE 11

### DIFF
--- a/components/modal/basic/src/index.js
+++ b/components/modal/basic/src/index.js
@@ -55,7 +55,10 @@ class ModalBasic extends Component {
   }
 
   _toggleWindowScroll(disableScroll) {
-    window.document.body.classList.toggle(CLASS_MODAL_OPEN, disableScroll)
+    const {classList} = window.document.body
+    disableScroll
+      ? classList.add(CLASS_MODAL_OPEN)
+      : classList.remove(CLASS_MODAL_OPEN)
   }
 
   _handleCloseClick = () => {


### PR DESCRIPTION
## ✍️ Description
- [x] Fixed `modal/basic` issue which caused random scroll paralysis in IE 11:
  - 🐛 classList: toggle() method's second argument [is not supported by IE 11](https://caniuse.com/#search=classlist%20toggle)