### PR TITLE
feat(cmp/ui): set text-align: center to sui-CmpUi-content

### DIFF
--- a/components/cmp/modal/src/index.scss
+++ b/components/cmp/modal/src/index.scss
@@ -7,6 +7,7 @@ $fz-sui-cmp-modal-inner: $fz-m !default;
 $w-sui-cmp-modal-logo: 150px !default;
 $maw-sui-cmp-modal-logo: 150px !default;
 $mah-sui-cmp-modal-logo: 40px !default;
+$ta-sui-cmp-modal-content: left !default;
 
 .sui-CmpModal {
   align-items: center;
@@ -64,6 +65,7 @@ $mah-sui-cmp-modal-logo: 40px !default;
     min-width: 320px;
     overflow: hidden;
     position: relative;
+    text-align: $ta-sui-cmp-modal-content;
     width: 100%;
     will-change: visibility, opacity;
   }

--- a/components/cmp/ui/src/index.scss
+++ b/components/cmp/ui/src/index.scss
@@ -5,6 +5,7 @@
 
 $bgc-cmp-ui: #fff !default;
 
+$ta-cmp-ui-content: left !default;
 $fz-cmp-ui-text-mobile: $fz-xs !default;
 $fz-cmp-ui-text-desktop: $fz-m !default;
 
@@ -55,6 +56,7 @@ $fz-cmp-ui-text-desktop: $fz-m !default;
   &-content {
     display: flex;
     flex-direction: column;
+    text-align: $ta-cmp-ui-content;
     @include media-breakpoint-up(s) {
       flex-direction: row;
       max-width: 1220px;


### PR DESCRIPTION
Not really a feature nor a fix, but a style change in order to ensure that the text on the content of the banner is properly displayed (`text-align: left`).

![image](https://user-images.githubusercontent.com/18154356/65320538-59d7a380-dba2-11e9-92d5-d5fac16202a7.png)
