### PR TITLE
Hotfix js error on modify unmounted element

### DIFF
--- a/components/topbar/user/.eslintrc
+++ b/components/topbar/user/.eslintrc
@@ -1,4 +1,0 @@
-{
-  "extends": ["standard", "standard-react"],
-  "parser": "babel-eslint"
-}

--- a/components/topbar/user/src/index.js
+++ b/components/topbar/user/src/index.js
@@ -74,7 +74,8 @@ class TopbarUser extends Component {
   _unlockBodyScroll = () => {
     const {elementsToKeepScrollOnToggleMenu} = this.props
     elementsToKeepScrollOnToggleMenu.forEach(selector => {
-      document.querySelector(selector).style.transform = ''
+      const element = document.querySelector(selector)
+      if (element) element.style.transform = ''
     })
     window.document.documentElement.classList.remove(HTML_HAS_SCROLL_DISABLED)
     window.document.body.classList.remove(BODY_HAS_SCROLL_DISABLED)

--- a/components/topbar/user/src/index.js
+++ b/components/topbar/user/src/index.js
@@ -73,6 +73,7 @@ class TopbarUser extends Component {
    */
   _unlockBodyScroll = () => {
     const {elementsToKeepScrollOnToggleMenu} = this.props
+
     elementsToKeepScrollOnToggleMenu.forEach(selector => {
       const element = document.querySelector(selector)
       if (element) element.style.transform = ''


### PR DESCRIPTION
If one of the selectors received on `elementsToKeepScrollOnToggleMenu` prop is not already mounted it will throw an error and breaks the entire page rendering

Also I remove eslintrtc because it was created before sui-lint be configured.

See https://github.com/SUI-Components/schibsted-spain-components/issues/131