### PR TITLE
feat(perf/dynamicRendering): reuse hook for intersection observer and simplify code

### DIFF
--- a/components/perf/dynamicRendering/package.json
+++ b/components/perf/dynamicRendering/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@s-ui/component-dependencies": "1",
-    "intersection-observer": "0.5.1"
+    "@schibstedspain/sui-react-hooks": "1"
   },
   "keywords": [],
   "author": "",

--- a/components/perf/dynamicRendering/src/index.js
+++ b/components/perf/dynamicRendering/src/index.js
@@ -7,7 +7,7 @@ const BOTS_USER_AGENTS = [
   'google-structured-data-testing-tool',
   'bingbot',
   'linkedinbot',
-  'mediapartners-google',
+  'mediapartners-google'
 ]
 
 function checkUserAgentIsBot(userAgent, botsUserAgents) {
@@ -24,7 +24,7 @@ export default function PerfDynamicRendering({
   height = 0,
   placeholder,
   rootMargin,
-  userAgent,
+  userAgent
 }) {
   const isBot = checkUserAgentIsBot(userAgent, botsUserAgents)
   const isOnBrowser = typeof window !== 'undefined'
@@ -97,5 +97,5 @@ PerfDynamicRendering.propTypes = {
   /**
    * An Array of strings that is used to set the lists of userAgents for which the element is always rendered
    */
-  botsUserAgents: PropTypes.arrayOf(PropTypes.string),
+  botsUserAgents: PropTypes.arrayOf(PropTypes.string)
 }

--- a/components/perf/dynamicRendering/src/index.js
+++ b/components/perf/dynamicRendering/src/index.js
@@ -1,13 +1,13 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import {LazyContent} from './lazyContent'
+import LazyContent from './lazyContent'
 
 const BOTS_USER_AGENTS = [
   'googlebot',
   'google-structured-data-testing-tool',
   'bingbot',
   'linkedinbot',
-  'mediapartners-google'
+  'mediapartners-google',
 ]
 
 function checkUserAgentIsBot(userAgent, botsUserAgents) {
@@ -17,14 +17,14 @@ function checkUserAgentIsBot(userAgent, botsUserAgents) {
 }
 
 export default function PerfDynamicRendering({
+  botsUserAgents = BOTS_USER_AGENTS,
   children,
   disabled,
   forceRender,
-  height,
-  userAgent,
+  height = 0,
   placeholder,
   rootMargin,
-  botsUserAgents
+  userAgent,
 }) {
   const isBot = checkUserAgentIsBot(userAgent, botsUserAgents)
   const isOnBrowser = typeof window !== 'undefined'
@@ -54,12 +54,8 @@ export default function PerfDynamicRendering({
     return <div style={{height: `${height}px`, marginBottom: '1px'}} />
   }
 }
-PerfDynamicRendering.displayName = 'PerfDynamicRendering'
 
-PerfDynamicRendering.defaultProps = {
-  height: 0,
-  botsUserAgents: BOTS_USER_AGENTS
-}
+PerfDynamicRendering.displayName = 'PerfDynamicRendering'
 
 PerfDynamicRendering.propTypes = {
   /**
@@ -101,5 +97,5 @@ PerfDynamicRendering.propTypes = {
   /**
    * An Array of strings that is used to set the lists of userAgents for which the element is always rendered
    */
-  botsUserAgents: PropTypes.arrayOf(PropTypes.string)
+  botsUserAgents: PropTypes.arrayOf(PropTypes.string),
 }

--- a/components/perf/dynamicRendering/src/lazyContent.js
+++ b/components/perf/dynamicRendering/src/lazyContent.js
@@ -1,73 +1,22 @@
-import React, {Component} from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
+import {useNearScreen} from '@schibstedspain/sui-react-hooks'
 
-export class LazyContent extends Component {
-  constructor(props) {
-    super(props)
-    this.refTarget = React.createRef()
+export default function LazyContent({
+  children,
+  rootMargin = '100px 0px 0px',
+  placeholder,
+  height,
+}) {
+  const [isNearScreen, fromRef] = useNearScreen({offset: rootMargin})
+
+  if (isNearScreen) {
+    return children
+  } else if (placeholder) {
+    return <div ref={fromRef}>{placeholder}</div>
+  } else {
+    return <div ref={fromRef} style={{height: `${height}px`}} />
   }
-
-  _observer = null
-
-  state = {
-    isIntersecting: false
-  }
-
-  handleChange = ([{isIntersecting}]) => {
-    if (isIntersecting) {
-      this.unobserve()
-      this._observer = null
-      this.setState({isIntersecting})
-    }
-  }
-
-  unobserve = () => {
-    try {
-      this._observer.unobserve(this.refTarget.current)
-    } catch (e) {
-      console.warn(e)
-    }
-  }
-
-  _startIntersectionObserver = () => {
-    this._observer = new window.IntersectionObserver(this.handleChange)
-    try {
-      this._observer.observe(this.refTarget.current, {
-        rootMargin: this.props.rootMargin
-      })
-    } catch (e) {
-      console.warn(e)
-    }
-  }
-
-  componentDidMount() {
-    if (!('IntersectionObserver' in window)) {
-      import('intersection-observer').then(this._startIntersectionObserver)
-    } else {
-      this._startIntersectionObserver()
-    }
-  }
-
-  componentWillUnmount() {
-    this._observer && this.unobserve()
-  }
-
-  render() {
-    const {isIntersecting: isVisible} = this.state
-    const {children, placeholder, height} = this.props
-
-    if (isVisible) {
-      return children
-    } else if (placeholder) {
-      return <div ref={this.refTarget}>{placeholder}</div>
-    } else {
-      return <div ref={this.refTarget} style={{height: `${height}px`}} />
-    }
-  }
-}
-
-LazyContent.defaultProps = {
-  rootMargin: '100px 0 0'
 }
 
 LazyContent.propTypes = {
@@ -90,5 +39,5 @@ LazyContent.propTypes = {
    * String in the format of the css margin property. the values serves to grow or shrink
    * each side of the root element's bounding box before computing intersections.
    */
-  rootMargin: PropTypes.string
+  rootMargin: PropTypes.string,
 }

--- a/components/perf/dynamicRendering/src/lazyContent.js
+++ b/components/perf/dynamicRendering/src/lazyContent.js
@@ -6,7 +6,7 @@ export default function LazyContent({
   children,
   rootMargin = '100px 0px 0px',
   placeholder,
-  height,
+  height
 }) {
   const [isNearScreen, fromRef] = useNearScreen({offset: rootMargin})
 
@@ -39,5 +39,5 @@ LazyContent.propTypes = {
    * String in the format of the css margin property. the values serves to grow or shrink
    * each side of the root element's bounding box before computing intersections.
    */
-  rootMargin: PropTypes.string,
+  rootMargin: PropTypes.string
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "enzyme-adapter-react-16": "1.14.0",
     "husky": "0.13.4",
     "jest": "24.8.0",
-    "validate-commit-msg": "2.12.2"
+    "validate-commit-msg": "2.12.2",
+    "@s-ui/lint": "3"
   },
   "dependencies": {
     "@s-ui/component-dependencies": "1",
@@ -54,17 +55,18 @@
   "commit-msg": [
     "validate-commit-msg"
   ],
+  "babel": {
+    "presets": [
+      "sui"
+    ]
+  },
   "eslintConfig": {
     "extends": [
       "./node_modules/@s-ui/lint/eslintrc.js"
     ]
   },
+  "prettier": "./node_modules/@s-ui/lint/.prettierrc.js",
   "stylelint": {
     "extends": "./node_modules/@s-ui/lint/stylelint.config.js"
-  },
-  "babel": {
-    "presets": [
-      "sui"
-    ]
   }
 }


### PR DESCRIPTION
Use `useNearScreen` own hook in order to simplify perf dynamic rendering implementation.
Also, it will have the `intersection-observer` in a single place, perfect to keep in sync the version and avoid installing more than once.