### PR TITLE
feat(abtesting/hooks): add onActivation event param to useExperimentCore

### DIFF
--- a/components/abtesting/hooks/src/useExperimentCore/index.js
+++ b/components/abtesting/hooks/src/useExperimentCore/index.js
@@ -3,12 +3,15 @@ import {useEffect, useState} from 'react'
 
 import OptimizelyX from './optimizely-x'
 
+const noop = () => {}
+
 export default params => {
   const {
     experimentId,
     forceActivation,
     forceActivationDelay = 1000,
     forceVariation,
+    onActivation = noop,
     variations: rawVariations
   } = params
 
@@ -94,7 +97,13 @@ export default params => {
 
   const activationHandler = rawVariationId => {
     const variationId = parseVariationId(rawVariationId)
-    return setState(buildExperimentState({...state, variationId, active: true}))
+    const newExperimentState = buildExperimentState({
+      ...state,
+      variationId,
+      active: true
+    })
+    onActivation(newExperimentState)
+    return setState(newExperimentState)
   }
 
   const logWatchOutMessage = message => {

--- a/components/abtesting/hooks/test/experiment-core.test.js
+++ b/components/abtesting/hooks/test/experiment-core.test.js
@@ -317,6 +317,37 @@ describe('Experiment', () => {
         'B'
       )
     })
+
+    it('should run a custom function for onActivation event and pass the new experiment data to it', () => {
+      let dataFromOnActivation
+
+      const Component = () => {
+        const experimentData = useExperiment({
+          experimentId: 40000,
+          onActivation: experimentData => {
+            dataFromOnActivation = experimentData
+          },
+          variations: [
+            {id: 700000, isDefault: true},
+            {id: 700001},
+            {id: 700002}
+          ]
+        })
+        const {variationName} = experimentData
+        return variationName
+      }
+
+      let mounted
+      act(() => {
+        mounted = mount(<Component />)
+      })
+
+      act(() => {
+        activationHandler(700002)
+      })
+      mounted.update()
+      expect(dataFromOnActivation.isVariationC).toBe(true)
+    })
   })
 
   describe('from useExperiment acting as a CONTEXT CONSUMER and OptimizelyXExperiment as a CORE RUNNER', () => {


### PR DESCRIPTION
## Description
The state-like data coming from `useExperiment` is ok in most cases, but sometimes you wanna run some code right when the activation happens. That's where an `onActivation` event is useful. It receives the updated experiment data as an argument.

## Tasks
- Add `onActivation` param to the core.
- Cover `onActivation` with a test.

## Note
A refactor of experiment tooling docs is pending. I'll soon include `onActivation` on it, not in this PR though.