### PR TITLE
Feat/move to now deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,13 @@ before_install:
 install:
   - npm install
   - npm run phoenix:ci 1>/dev/null
-  - npm run lint
-  - npm run test
 
 jobs:
   include:
+    - stage: Lint & Test
+      script:
+        - npm run lint
+        - npm run test
     - stage: Release
       if: branch = master AND NOT type = pull_request
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ language: node_js
 node_js:
   - '13'
 
+before_install:
+  - npm config set //registry.npmjs.org/:_authToken $NPM_TOKEN
+
 install:
   - npm install
   - npm run phoenix:ci 1>/dev/null

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,11 @@
-dist: xenial
+dist: bionic
 
 sudo: false
 
 language: node_js
 
 node_js:
-  - '11'
-
-before_install:
-  - npm config set //registry.npmjs.org/:_authToken $NPM_TOKEN
+  - '13'
 
 install:
   - npm install
@@ -18,18 +15,7 @@ install:
 
 jobs:
   include:
-    - stage: Deploy
-      if: branch = master AND type = pull_request
-      script:
-        - npm install now@14 -g
-        - npm run build
-        - cp now.json ./public/now.json
-        - now ./public -t $NOW_TOKEN
-    - stage: Deploy
+    - stage: Release
       if: branch = master AND NOT type = pull_request
       script:
-        - npm install now@14 -g
-        - npm run build
-        - cp now.json ./public/now.json
-        - now ./public -t $NOW_TOKEN --target production
         - sh .travis-release.sh

--- a/components/form/builder/package.json
+++ b/components/form/builder/package.json
@@ -14,8 +14,7 @@
     "@s-ui/react-molecule-dropdown-option": "1",
     "@s-ui/react-molecule-input-field": "2",
     "@s-ui/react-molecule-select-field": "1",
-    "@s-ui/react-molecule-textarea-field": "2",
-    "@schibstedspain/mt-svg-icons": "1"
+    "@s-ui/react-molecule-textarea-field": "2"
   },
   "keywords": [],
   "author": "",

--- a/components/form/builder/src/components/IconAngleDown.js
+++ b/components/form/builder/src/components/IconAngleDown.js
@@ -1,0 +1,40 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+export default function IconAngleDown({
+  size = 24,
+  strokeColor = 'none',
+  strokeWidth = 0,
+  fillColor = '#777',
+  svgClass = 'mt-Icon'
+}) {
+  const inlineStyling = {
+    fill: fillColor,
+    stroke: strokeColor,
+    strokeWidth: strokeWidth
+  }
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      style={inlineStyling}
+      className={svgClass}
+      viewBox="0 0 24 24"
+    >
+      <path
+        d="M12,16.6L3.8,8.4c-0.2-0.2-0.2-0.6,0-0.8c0.2-0.2,0.6-0.2,0.8,0L12,15l7.4-7.4c0.2-0.2,0.6-0.2,0.8,0
+c0.2,0.2,0.2,0.6,0,0.8L12,16.6z"
+      />
+    </svg>
+  )
+}
+
+IconAngleDown.propTypes = {
+  strokeColor: PropTypes.string,
+  strokeWidth: PropTypes.number,
+  fillColor: PropTypes.string,
+  size: PropTypes.number,
+  svgClass: PropTypes.string
+}

--- a/components/form/builder/src/components/IconClose.js
+++ b/components/form/builder/src/components/IconClose.js
@@ -1,0 +1,36 @@
+import React from 'react'
+
+export default function IconClose({
+  size = 24,
+  strokeColor = 'none',
+  strokeWidth = 0,
+  fillColor = '#777',
+  svgClass = 'mt-Icon'
+}) {
+  const inlineStyling = {
+    fill: fillColor,
+    stroke: strokeColor,
+    strokeWidth: strokeWidth
+  }
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      style={inlineStyling}
+      className={svgClass}
+      viewBox="0 0 64 64"
+    >
+      <path d="M60,62a2,2,0,0,1-1.41-.59L32,34.83,5.41,61.41a2,2,0,0,1-2.83-2.83L29.17,32,2.59,5.41A2,2,0,0,1,5.41,2.59L32,29.17,58.59,2.59a2,2,0,0,1,2.83,2.83L34.83,32,61.41,58.59A2,2,0,0,1,60,62Z" />
+    </svg>
+  )
+}
+
+IconClose.propTypes = {
+  strokeColor: 'none',
+  strokeWidth: 0,
+  fillColor: '#777777',
+  size: 24,
+  svgClass: 'mt-Icon'
+}

--- a/components/form/builder/src/components/select.js
+++ b/components/form/builder/src/components/select.js
@@ -4,8 +4,8 @@ import PropTypes from 'prop-types'
 import MoleculeSelectField from '@s-ui/react-molecule-select-field'
 import MoleculeSelectOption from '@s-ui/react-molecule-dropdown-option'
 
-import IconAngleDown from '@schibstedspain/mt-svg-icons/lib/IconAngleDown'
-import IconClose from '@schibstedspain/mt-svg-icons/lib/IconClose'
+import IconAngleDown from './IconAngleDown'
+import IconClose from './IconClose'
 
 import WithValidator from '../validatorHoC/WithValidator'
 

--- a/components/form/builder/src/index.js
+++ b/components/form/builder/src/index.js
@@ -78,7 +78,7 @@ class FormBuilder extends Component {
    * @param {Object} currentField
    * @param {string} currentValueId
    */
-  _getSelectedFormValues = (nextField, currentField, currentValuedId) => {
+  _getSelectedFormValues = (nextField, currentField, currentValueId) => {
     const maxIndex = this._formFields.indexOf(nextField)
     const selectedFields = this._formFields.filter(
       (_, index) => index < maxIndex
@@ -86,7 +86,7 @@ class FormBuilder extends Component {
     const selectedFormValues = this._getFormValues(
       selectedFields,
       currentField,
-      currentValuedId
+      currentValueId
     )
     return selectedFormValues
   }
@@ -366,7 +366,7 @@ FormBuilder.propTypes = {
     /** Refers to the formfield label */
     label: PropTypes.string,
     /** Refers to the formfield errors */
-    errors: PropTypes.Object,
+    errors: PropTypes.object,
     /** Refers to whether formField is persistent */
     persists: PropTypes.bool,
     /** Refers to the formfield input type */

--- a/now.json
+++ b/now.json
@@ -1,4 +1,5 @@
 {
+  "name": "schibsted-spain-components",
   "version": 2,
   "routes": [
     { "handle": "filesystem" },

--- a/now.json
+++ b/now.json
@@ -1,6 +1,7 @@
 {
   "version": 2,
-  "name": "schibstedspain-react-components",
-  "public": true,
-  "alias": "schibstedspain-react-components"
+  "routes": [
+    { "handle": "filesystem" },
+    { "src": "/.*", "dest": "/index.html" }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
   },
   "config": {
     "sui-studio": {
-      "logo": "<img width='50' src='https://pbs.twimg.com/profile_images/575607908940931073/gGXmL_b3.jpeg' />",
+      "logo": "<img width='50' src='https://camo.githubusercontent.com/60172890c1c8e95d3d0f51f09399a3504f89ef88/68747470733a2f2f7777772e61646576696e74612e636f6d2f77702d636f6e74656e742f7468656d65732f73636f6d2f6173736574732f696d672f41646576696e74612d6c6f676f2e737667' />",
       "font": "https://fonts.googleapis.com/css?family=Open+Sans:400,400i,700,700i",
-      "name": "Schibsted Spain Components"
+      "name": "Adevinta Spain Components"
     },
     "sui-mono": {
       "access": "public",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@s-ui/component-dependencies": "1",
-    "@s-ui/mono": "beta"
+    "@s-ui/mono": "1"
   },
   "config": {
     "sui-studio": {

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "lint": "npm run lint:js && npm run lint:sass",
     "lint:js": "sui-lint js",
     "lint:sass": "sui-lint sass",
-    "install:demos": "cd demo && sui-mono phoenix",
-    "phoenix": "sui-mono phoenix && npm run install:demos -- --no-audit",
-    "phoenix:ci": "sui-mono phoenix --no-root --no-audit --no-progress && npm run install:demos -- --no-audit --no-progress",
+    "install:demos": "cd demo && sui-mono phoenix --ci",
+    "phoenix": "sui-mono phoenix && npm run install:demos",
+    "phoenix:ci": "sui-mono phoenix --no-root --ci && npm run install:demos -- --ci",
     "precommit": "sui-precommit run",
     "start": "sui-studio start",
     "test": "jest"
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@s-ui/component-dependencies": "1",
-    "@s-ui/mono": "1"
+    "@s-ui/mono": "beta"
   },
   "config": {
     "sui-studio": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Mono repo containing all Schibsted Spain React Components.",
   "private": true,
   "scripts": {
-    "build": "sui-mono phoenix --no-root --no-audit --no-progress && npm run install:demos -- --no-audit --no-progress && sui-studio build",
+    "build": "npm run phoenix:ci && sui-studio build",
     "co": "sui-studio commit",
     "commitmsg": "validate-commit-msg",
     "dev": "sui-studio dev",
@@ -14,6 +14,7 @@
     "lint:sass": "sui-lint sass",
     "install:demos": "cd demo && sui-mono phoenix",
     "phoenix": "sui-mono phoenix && npm run install:demos -- --no-audit",
+    "phoenix:ci": "sui-mono phoenix --no-root --no-audit --no-progress && npm run install:demos -- --no-audit --no-progress",
     "precommit": "sui-precommit run",
     "start": "sui-studio start",
     "test": "jest"

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@schibstedspain/react-components",
-  "version": "1.2.0",
+  "version": "1.0.0",
   "description": "Mono repo containing all Schibsted Spain React Components.",
   "private": true,
   "scripts": {
-    "build": "sui-studio build",
+    "build": "sui-mono phoenix --no-root --no-audit --no-progress && npm run install:demos -- --no-audit --no-progress && sui-studio build",
     "co": "sui-studio commit",
     "commitmsg": "validate-commit-msg",
     "dev": "sui-studio dev",
@@ -12,8 +12,8 @@
     "lint": "npm run lint:js && npm run lint:sass",
     "lint:js": "sui-lint js",
     "lint:sass": "sui-lint sass",
-    "phoenix": "sui-mono phoenix && (cd demo && sui-mono phoenix)",
-    "phoenix:ci": "sui-mono run-parallel npm install && (cd demo && sui-mono run-parallel npm install)",
+    "install:demos": "cd demo && sui-mono phoenix",
+    "phoenix": "sui-mono phoenix && npm run install:demos -- --no-audit",
     "precommit": "sui-precommit run",
     "start": "sui-studio start",
     "test": "jest"
@@ -23,14 +23,14 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@babel/plugin-transform-modules-commonjs": "7.4.0",
+    "@babel/plugin-transform-modules-commonjs": "7.7.5",
     "@s-ui/precommit": "2",
-    "@s-ui/studio": "6",
+    "@s-ui/studio": "7",
     "enzyme": "3.10.0",
-    "enzyme-adapter-react-16": "1.14.0",
+    "enzyme-adapter-react-16": "1.15.1",
     "husky": "0.13.4",
-    "jest": "24.8.0",
-    "validate-commit-msg": "2.12.2",
+    "jest": "24.9.0",
+    "validate-commit-msg": "2.14.0",
     "@s-ui/lint": "3"
   },
   "dependencies": {


### PR DESCRIPTION
🆕 NOW deployment enabled. Integrated with GitHub.
❌ No more `Error: X-Now-Shallow response header was null`. FINALLY!!!!
🚀 Blazing fast deployments. **2 minutes** and you're ready to go!
🧹Remove @s-ui/deploy dependency and travis deployment.
🆙 Upgrade major dependencies
👩‍🏫 Simplify codebase when creating demos
🔀 Integrated deployment per branch with automatic comment
🔉 Less noise on the deployment log by muting some messages