### PR TITLE
feat(components/form/builder): add tabIndex config field that can rep…

### DIFF
--- a/components/form/builder/src/FieldSet/index.js
+++ b/components/form/builder/src/FieldSet/index.js
@@ -30,20 +30,23 @@ const FieldSet = ({
         </legend>
       )}
       <div className={`${baseClass}Container`}>
-        {fields.map((field, index) => (
-          <ProxyField
-            onChange={onChange}
-            onFocus={onFocus}
-            onBlur={onBlur}
-            key={field.id}
-            field={field}
-            tabIndex={tabIndex + index * 0.1}
-            fieldSize={fieldSize}
-            errors={errors}
-            alerts={alerts}
-            renderer={renderer}
-          />
-        ))}
+        {fields.map((field, index) => {
+          const fieldTabIndex = field.tabIndex ?? tabIndex + index * 0.1
+          return (
+            <ProxyField
+              onChange={onChange}
+              onFocus={onFocus}
+              onBlur={onBlur}
+              key={field.id}
+              field={field}
+              tabIndex={fieldTabIndex}
+              fieldSize={fieldSize}
+              errors={errors}
+              alerts={alerts}
+              renderer={renderer}
+            />
+          )
+        })}
       </div>
     </fieldset>
   )

--- a/components/form/builder/src/index.js
+++ b/components/form/builder/src/index.js
@@ -133,20 +133,23 @@ const FormBuilder = ({
 
   return (
     <div className="sui-FormBuilder">
-      {stateFields.map((field, index) => (
-        <ProxyField
-          key={field.id}
-          field={field}
-          tabIndex={index + 1}
-          onChange={handlerChange}
-          onBlur={onBlur}
-          onFocus={onFocus}
-          fieldSize={fieldSize}
-          errors={errors}
-          alerts={alerts}
-          renderer={renderer}
-        />
-      ))}
+      {stateFields.map((field, index) => {
+        const tabIndex = field.tabIndex ?? index + 1
+        return (
+          <ProxyField
+            key={field.id}
+            field={field}
+            tabIndex={tabIndex}
+            onChange={handlerChange}
+            onBlur={onBlur}
+            onFocus={onFocus}
+            fieldSize={fieldSize}
+            errors={errors}
+            alerts={alerts}
+            renderer={renderer}
+          />
+        )
+      })}
       {stateShowSpinner && (
         <AtomSpinner type={AtomSpinnerTypes.SECTION} loader={loader} />
       )}


### PR DESCRIPTION
Added the possibility to set a custom field tabindexes to replace the default ones.

In my case, I will replace all tabIndexes to value `0` on coches.net PTA to be more accessible, now is doing weird jumping between fields. Also, it seems to be a good practice as read on https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex
![Captura de pantalla 2021-10-11 a las 19 03 34](https://user-images.githubusercontent.com/37936498/136828638-a73e7646-d271-499f-91d0-6fd6ca6db73c.png)

You can add it to config field this way: 
```
{
    id: fieldNames.year,
    context: 'years',
    type: 'picker',
    display: 'dropdown',
    label: i18n.t('COMMON.YEAR'),
    hint: i18n.t('PUBLISH_AD.FB.YEARS.HINT'),
    disabled: true,
    required: true,
    tabIndex: 0,     <--------- add a number value here to set custom tabIndex
    constraints: [
      {
        property: {
          notnull: ''
        },
        message: i18n.t('PUBLISH_AD.FB.YEARS.CONSTRAINTS.NOTNULL')
      }
    ]
  }
```