### PR TITLE
fix(components/form/builder): add inlineButton destructuring default value

### DIFF
--- a/components/form/builder/src/InlineButton/index.js
+++ b/components/form/builder/src/InlineButton/index.js
@@ -47,10 +47,11 @@ const InlineButton = ({inlineButton, tabIndex, onChange, errors, alerts, rendere
     return null
   }
 
-  const {selectedIcon: SelectedIcon, ...rendererResponse} = renderer({
-    id: inlineButton.id,
-    innerProps: {...inlineButtonProps, datalist, display: inlineButton.display}
-  })
+  const {selectedIcon: SelectedIcon, ...rendererResponse} =
+    renderer({
+      id: inlineButton.id,
+      innerProps: {...inlineButtonProps, datalist, display: inlineButton.display}
+    }) || {}
 
   // render custom component
   if (isValidElement(rendererResponse)) return rendererResponse


### PR DESCRIPTION
Add inlineButton destructuring default value to not crash:

```
react-dom.development.js:26957 Uncaught TypeError: Cannot read properties of undefined (reading 'selectedIcon')
    at InlineButton (index.js:73:30)
    at renderWithHooks (react-dom.development.js:15486:18)
    at mountIndeterminateComponent (react-dom.development.js:20098:13)
    at beginWork (react-dom.development.js:21621:16)
    at beginWork$1 (react-dom.development.js:27460:14)
    at performUnitOfWork (react-dom.development.js:26591:12)
    at workLoopSync (react-dom.development.js:26500:5)
    at renderRootSync (react-dom.development.js:26468:7)
    at recoverFromConcurrentError (react-dom.development.js:25884:20)
    at performConcurrentWorkOnRoot (react-dom.development.js:25784:22)
```
![image](https://github.com/user-attachments/assets/f5b82631-293b-411b-a7d7-bc090db4c4f7)
